### PR TITLE
Feature/optimization fix

### DIFF
--- a/photonai/optimization/__init__.py
+++ b/photonai/optimization/__init__.py
@@ -7,7 +7,6 @@ from .grid_search.grid_search import GridSearchOptimizer, RandomGridSearchOptimi
 from .scikit_optimize.sk_opt import SkOptOptimizer
 from .random_search.random_search import RandomSearchOptimizer
 from .smac.smac import SMACOptimizer
-# from .smac.smac3 import SMACOptimizer
 
 #
 # __all__ = ("GridSearchOptimizer",

--- a/photonai/optimization/base_optimizer.py
+++ b/photonai/optimization/base_optimizer.py
@@ -7,14 +7,6 @@ class PhotonBaseOptimizer:
     def __init__(self, *kwargs):
         pass
 
-    def prepare(self, pipeline_elements: list, maximize_metric: bool):
-        """
-        Initializes hyperparameter search.
-        Assembles all hyperparameters of the pipeline_element list in order to prepare the hyperparameter search space.
-        Hyperparameters can be accessed via pipe_element.hyperparameters.
-        """
-        pass
-
     def plot(self, results_folder):
         """
         Plot optimizer specific visualizations
@@ -43,9 +35,28 @@ class PhotonBaseOptimizer:
 
 
 class PhotonSlaveOptimizer(PhotonBaseOptimizer):
+    """
+    The PhotonSlaveOptimizer is controlled by PHOTON. By ask-tell principle PHOTON get new configs.
+    It terminates by some specific criteria with an aks -> empty yield.
+    """
 
     def __init__(self, *kwargs):
         super(PhotonSlaveOptimizer, self).__init__(kwargs)
+
+    def prepare(self, pipeline_elements: list, maximize_metric: bool):
+        """
+        Initializes hyperparameter search.
+        Assembles all hyperparameters of the pipeline_element list in order to prepare the hyperparameter search space.
+        Hyperparameters can be accessed via pipe_element.hyperparameters.
+
+        Parameters
+        ----------
+        * `pipeline_elements` [list]:
+            List of all pipeline_elements to create hyperparameter_space.
+        * `maximize_metric` [bool]:
+            Boolean for distinguish between score and error.
+        """
+        pass
 
     def ask(self):
         """
@@ -70,13 +81,33 @@ class PhotonSlaveOptimizer(PhotonBaseOptimizer):
 
 
 class PhotonMasterOptimizer(PhotonBaseOptimizer):
+    """
+        The PhotonMasterOptimizer controls PHOTON. PHOTON provides an objective_function.
+        The runs and configs of the objective_function is up to PhotonMasterOptimizer.
+        """
 
     def __init__(self, *kwargs):
-        super(PhotonSlaveOptimizer, self).__init__(kwargs)
+        super(PhotonMasterOptimizer, self).__init__(kwargs)
+
+    def prepare(self, pipeline_elements: list, maximize_metric: bool, objective_function):
+        """
+        Initializes hyperparameter search.
+        Assembles all hyperparameters of the pipeline_element list in order to prepare the hyperparameter search space.
+        Hyperparameters can be accessed via pipe_element.hyperparameters.
+
+        Parameters
+        ----------
+        * `pipeline_elements` [list]:
+            List of all pipeline_elements to create hyperparameter_space.
+        * `maximize_metric` [bool]:
+            Boolean for distinguish between score and error.
+        * `objective_function` [callable]:
+            The cost or objective function.
+        """
+        pass
 
     def optimize(self):
         """
-
-        :return:
+        Start optimization over objective_function.
         """
         pass

--- a/photonai/optimization/hyperparameters.py
+++ b/photonai/optimization/hyperparameters.py
@@ -8,7 +8,15 @@ class PhotonHyperparam(object):
     def __init__(self, values):
         self.values = values
 
-    def get_random_value(self, definite_list:bool=True):
+    def get_random_value(self, definite_list: bool = True):
+        """
+        Method for random search to get random parameter based on its domain.
+
+        Parameters
+        ----------
+        * `definite_list` [bool: True]:
+             Choice of transform param to discret list or not.
+        """
         if definite_list:
             return random.choice(self.values)
         else:
@@ -18,7 +26,6 @@ class PhotonHyperparam(object):
 
     def __str__(self):
         return str(self.__class__) + str(self.values)
-
 
 
 class Categorical(PhotonHyperparam):
@@ -34,7 +41,7 @@ class Categorical(PhotonHyperparam):
     """
 
     def __init__(self, values: list):
-        self.values = values
+        super(Categorical, self).__init__(values)
 
     def __getitem__(self, item):
         return self.values.__getitem__(item)
@@ -55,7 +62,7 @@ class BooleanSwitch(PhotonHyperparam):
     """
 
     def __init__(self):
-        self.values = [True, False]
+        super(BooleanSwitch, self).__init__([True, False])
 
 
 class NumberRange(PhotonHyperparam):
@@ -110,14 +117,13 @@ class NumberRange(PhotonHyperparam):
     """
 
     def __init__(self, start, stop, range_type, step=None, num=None, num_type=np.int64, **kwargs):
-
+        super(NumberRange, self).__init__(None)
         self.start = start
         self.stop = stop
         self._range_type = None
         self.range_type = range_type
         self.range_params = kwargs
         self.num_type = num_type
-        self.values = None
         self.step = step
         self.num = num
 
@@ -130,7 +136,7 @@ class NumberRange(PhotonHyperparam):
         if self.range_type == "range" and self.start > self.stop:
             warn_message = "NumberRange or one of its subclasses is empty cause np.arange " + \
                            "does not deal with start greater than stop."
-            logger.warn(warn_message)
+            logger.warning(warn_message)
 
         values = []
 
@@ -156,11 +162,6 @@ class NumberRange(PhotonHyperparam):
                 values = np.geomspace(self.start, self.stop, num=self.num, dtype=self.num_type, **self.range_params)
             else:
                 values = np.geomspace(self.start, self.stop, dtype=self.num_type, **self.range_params)
-        else:
-            msg = "PHOTON can not create values of your NumberRange cause of unknowing range_type: {}. " \
-                  "Please use one of ['range', 'linspace', 'logspace', 'geomspace']."
-            logger.error(msg.format(self.range_type))
-            raise ValueError(msg.format(self.range_type))
 
         # convert to python datatype because mongodb needs it
         if np.issubdtype(self.num_type, np.integer):
@@ -240,6 +241,7 @@ class IntegerRange(NumberRange):
         else:
             return random.randint(self.start, self.stop-1)
 
+
 class FloatRange(NumberRange):
     """
           Class for easily creating a range of integer numbers to be tested in hyperparameter optimization.
@@ -281,7 +283,7 @@ class FloatRange(NumberRange):
         """
 
     def __init__(self, start, stop, range_type='linspace', step=None, num=None, **kwargs):
-            super().__init__(start, stop, range_type, step, num, np.float64, **kwargs)
+        super(FloatRange, self).__init__(start, stop, range_type, step, num, np.float64, **kwargs)
 
     def get_random_value(self, definite_list: bool = False):
         if definite_list:

--- a/photonai/optimization/hyperparameters.py
+++ b/photonai/optimization/hyperparameters.py
@@ -12,7 +12,7 @@ class PhotonHyperparam(object):
         if definite_list:
             return random.choice(self.values)
         else:
-            msg = "The PhotonHyperparam has no own random function."
+            msg = "The PHOTON hyperparam has no own random function."
             logger.error(msg)
             raise ValueError(msg)
 
@@ -156,11 +156,22 @@ class NumberRange(PhotonHyperparam):
                 values = np.geomspace(self.start, self.stop, num=self.num, dtype=self.num_type, **self.range_params)
             else:
                 values = np.geomspace(self.start, self.stop, dtype=self.num_type, **self.range_params)
+        else:
+            msg = "PHOTON can not create values of your NumberRange cause of unknowing range_type: {}. " \
+                  "Please use one of ['range', 'linspace', 'logspace', 'geomspace']."
+            logger.error(msg.format(self.range_type))
+            raise ValueError(msg.format(self.range_type))
+
         # convert to python datatype because mongodb needs it
-        if self.num_type == np.int32:
+        if np.issubdtype(self.num_type, np.integer):
             self.values = [int(i) for i in values]
-        elif self.num_type == np.float32:
+        elif np.issubdtype(self.num_type, np.floating):
             self.values = [float(i) for i in values]
+        else:
+            msg = "PHOTON can not guarantee full mongodb support since you chose a non [np.integer, np.floating] " \
+                  "subtype in NumberType.dtype."
+            logger.warn(msg)
+            self.values = values
 
     @property
     def range_type(self):
@@ -269,8 +280,8 @@ class FloatRange(NumberRange):
             Further parameters that should be passed to the numpy function chosen with range_type.
         """
 
-    def __init__(self, start, stop, range_type='range', step=None, num=None, **kwargs):
-            super().__init__(start, stop, range_type, step, num, np.float32, **kwargs)
+    def __init__(self, start, stop, range_type='linspace', step=None, num=None, **kwargs):
+            super().__init__(start, stop, range_type, step, num, np.float64, **kwargs)
 
     def get_random_value(self, definite_list: bool = False):
         if definite_list:

--- a/photonai/optimization/smac/smac.py
+++ b/photonai/optimization/smac/smac.py
@@ -33,8 +33,7 @@ class SMACOptimizer(PhotonMasterOptimizer):
             msg = "Module smac not found or not installed as expected. " \
                   "Please install the smac_requirements.txt PHOTON provides."
             logger.error(msg)
-            raise ModuleNotFoundError("Module smac not found or not installed as expected. "
-                                      "Please install the smac_requirements.txt PHOTON provides.")
+            raise ModuleNotFoundError(msg)
 
         if not scenario_dict:
             self.scenario_dict = {"run_obj": "quality",
@@ -49,18 +48,14 @@ class SMACOptimizer(PhotonMasterOptimizer):
         if not facade:
             self.facade = SMAC4HPO
         else:
-            if type(facade) == str:
-                if facade in ["SMAC4BO", "SMAC4AC", "SMAC4HPO"]:
+            if facade in ["SMAC4BO", SMAC4BO, "SMAC4AC", SMAC4AC, "SMAC4HPO", SMAC4HPO]:
+                if type(facade) == str:
                     self.facade = eval(facade)
                 else:
-                    msg = "Dont understand SMAC.facade {}. Please use one of ['SMAC4BO', 'SMAC4AC', 'SMAC4HPO']."
-                    logger.error(msg)
-                    raise ValueError(msg)
-            elif isinstance(facade, SMAC4BO) or isinstance(facade, SMAC4AC) or isinstance(facade, SMAC4HPO):
-                self.facade = facade
+                    self.facade = facade
             else:
-                msg = "Dont understand SMAC.facade. Please use one of ['SMAC4BO', 'SMAC4AC', 'SMAC4HPO']."
-                logger.error(msg)
+                msg = "SMAC.facade {} not known. Please use one of ['SMAC4BO', 'SMAC4AC', 'SMAC4HPO']."
+                logger.error(msg.format(str(facade)))
                 raise ValueError(msg)
 
         self.rng = rng

--- a/photonai/optimization/smac/smac.py
+++ b/photonai/optimization/smac/smac.py
@@ -17,17 +17,28 @@ except ModuleNotFoundError:
 
 class SMACOptimizer(PhotonMasterOptimizer):
 
-    def __init__(self, facade=None, scenario_dict=None, intensifier_kwargs=None, rng=42, smac_helper = None):
+    def __init__(self, facade='SMAC4HPO', scenario_dict=None, intensifier_kwargs=None, rng=42, smac_helper=None):
         """
         SMAC Wrapper for PHOTON.
         SMAC usage and implementation details:
         https://automl.github.io/SMAC3/master/quickstart.html
 
-        :param facade: str or object for SMAC strategy
-        :param scenario_dict: dict for scenario settings
-        :param rng: INT for random seed
-        :param smac_helper: currently help object for test cases.
+        Parameters
+        ----------
+        * `facade` [str or smac.facade.class, default: 'SMAC4HPO']:
+             Choice of SMAC backend strategy, [SMAC4BO, SMAC4HPO, SMAC4AC].
+        * `scenario_dict` [dict, default: None (warning scenario with wallclock_limit = 60*40)]
+            Informations for scenario settings like run_limit or wallclock_limit.
+            Different to main SMAC cs (configspace) is not required or used cause PHOTON translate own param_space
+            to SMAC.configspace.
+        * `rng`: [int, default: 42]
+            random seed of SMAC.facade
+        * `smac_helper` [dict]
+            For testing this object give public access to SMAC.facade object.
+            Currently help object for test cases.
         """
+
+        super(SMACOptimizer, self).__init__()
 
         if not __found__:
             msg = "Module smac not found or not installed as expected. " \
@@ -37,26 +48,22 @@ class SMACOptimizer(PhotonMasterOptimizer):
 
         if not scenario_dict:
             self.scenario_dict = {"run_obj": "quality",
-                             "deterministic": "true",
-                             "wallclock_limit": 60 * 40
-                             }
+                                  "deterministic": "true",
+                                  "wallclock_limit": 60 * 40}
             msg = "No scenario_dict for smac was given. Falling back to default values: {}.".format(self.scenario_dict)
-            logger.warn(msg)
+            logger.warning(msg)
         else:
             self.scenario_dict = scenario_dict
 
-        if not facade:
-            self.facade = SMAC4HPO
-        else:
-            if facade in ["SMAC4BO", SMAC4BO, "SMAC4AC", SMAC4AC, "SMAC4HPO", SMAC4HPO]:
-                if type(facade) == str:
-                    self.facade = eval(facade)
-                else:
-                    self.facade = facade
+        if facade in ["SMAC4BO", SMAC4BO, "SMAC4AC", SMAC4AC, "SMAC4HPO", SMAC4HPO]:
+            if type(facade) == str:
+                self.facade = eval(facade)
             else:
-                msg = "SMAC.facade {} not known. Please use one of ['SMAC4BO', 'SMAC4AC', 'SMAC4HPO']."
-                logger.error(msg.format(str(facade)))
-                raise ValueError(msg)
+                self.facade = facade
+        else:
+            msg = "SMAC.facade {} not known. Please use one of ['SMAC4BO', 'SMAC4AC', 'SMAC4HPO']."
+            logger.error(msg.format(str(facade)))
+            raise ValueError(msg)
 
         self.rng = rng
         if not intensifier_kwargs:
@@ -64,9 +71,7 @@ class SMACOptimizer(PhotonMasterOptimizer):
         else:
             self.intensifier_kwargs = intensifier_kwargs
 
-        self.cspace = ConfigurationSpace()  # Hyperparameter space for smac
-
-
+        self.cspace = ConfigurationSpace()  # Hyperparameter space for SMAC
         self.switch_optiones = {}
         self.hyperparameters = []
 
@@ -78,11 +83,17 @@ class SMACOptimizer(PhotonMasterOptimizer):
 
         self.maximize_metric = False
 
-
     @staticmethod
-    def _convert_photon_to_smac_space(hyperparam: object, name: str):
+    def _convert_photon_to_smac_param(hyperparam: object, name: str):
         """
-        Helper function: Convert PHOTON hyperparams to smac params.
+        Helper function: Convert PHOTON hyperparameter to SMAC hyperparameter.
+
+        Parameters
+        ----------
+        * `hyperparam` [object]:
+             One of photonai.optimization.hyperparameters.
+        * `name` [str]
+            Name of hyperparameter.
         """
         if not hyperparam:
             return None
@@ -102,7 +113,12 @@ class SMACOptimizer(PhotonMasterOptimizer):
 
     def build_smac_space(self, pipeline_elements):
         """
-        Build entire smac hyperparam space.
+        Build entire SMAC hyperparameter space.
+
+        Parameters
+        ----------
+        * `pipeline_elements` [list]:
+            List of all pipeline_elements to create hyperparameter_space.
         """
         for pipe_element in pipeline_elements:
             # build conditions for switch elements
@@ -111,12 +127,12 @@ class SMACOptimizer(PhotonMasterOptimizer):
                 for algo in pipe_element.elements:
                     algo_params = []  # hyper params corresponding to "algo"
                     for name, value in algo.hyperparameters.items():
-                        smac_param = self._convert_photon_to_smac_space(value, (
+                        smac_param = self._convert_photon_to_smac_param(value, (
                                 pipe_element.name + "__" + name))  # or element.name__algo.name__name
                         algo_params.append(smac_param)
                     algorithm_options[(pipe_element.name + "__" + algo.name)] = algo_params
 
-                algos = CategoricalHyperparameter(name=pipe_element.name + "__algos", choices=algorithm_options.keys())
+                algos = CategoricalHyperparameter(pipe_element.name + "__algos", choices=algorithm_options.keys())
 
                 self.switch_optiones[pipe_element.name + "__algos"] = algorithm_options.keys()
 
@@ -138,17 +154,22 @@ class SMACOptimizer(PhotonMasterOptimizer):
                     if isinstance(value, PhotonCategorical) and len(value.values) < 2:
                         self.constant_dictionary[name] = value.values[0]
                         continue
-                    smac_param = self._convert_photon_to_smac_space(value, name)
+                    smac_param = self._convert_photon_to_smac_param(value, name)
                     if smac_param is not None:
                         self.cspace.add_hyperparameter(smac_param)
 
-    def prepare(self, pipeline_elements: list, maximize_metric: bool, objectiv_function):
+    def prepare(self, pipeline_elements: list, maximize_metric: bool, objective_function):
         """
         Initializes SMAC Optimizer.
-        :param pipeline_elements: PHOTON Elments to cast
-        :param maximize_metric: error or score distinction
-        :param objectiv_function: function cfg -> cost
-        :return:
+
+        Parameters
+        ----------
+        * `pipeline_elements` [list]:
+            List of all pipeline_elements to create hyperparameter_space.
+        * `maximize_metric` [bool]:
+            Boolean for distinguish between score and error.
+        * `objective_function` [callable]:
+            The cost or objective function.
         """
         self.space = ConfigurationSpace()  # build space
         self.build_smac_space(pipeline_elements)
@@ -161,8 +182,7 @@ class SMACOptimizer(PhotonMasterOptimizer):
         self.smac = self.facade(scenario = self.scenario,
                                 intensifier_kwargs = self.intensifier_kwargs,
                                 rng = self.rng,
-                                tae_runner = objectiv_function)
-
+                                tae_runner = objective_function)
 
         if  self.debug:
             self.smac_helper['data'] = self.smac
@@ -170,6 +190,6 @@ class SMACOptimizer(PhotonMasterOptimizer):
 
     def optimize(self):
         """
-        Start optimization process
+        Start optimization process.
         """
         self.smac.optimize()

--- a/photonai/test/optimization_tests/hyperparameters_test.py
+++ b/photonai/test/optimization_tests/hyperparameters_test.py
@@ -33,6 +33,20 @@ class BaseTest(unittest.TestCase):
             self.assertIn(self.intger_range.get_random_value(definite_list=True), self.intger_range.values)
             self.assertIn(self.float_range.get_random_value(definite_list=True), self.float_range.values)
 
+    def test_domain(self):
+
+        self.float_range.transform()
+        self.intger_range.transform()
+        self.assertListEqual(self.intger_range.values, list(np.arange(2,6)))
+        self.assertListEqual(self.float_range.values, list(np.linspace(0.1, 5.7, dtype=np.float64)))
+
+        big_float_range = FloatRange(-300.57, np.pi*4000)
+        big_float_range.transform()
+        self.assertListEqual(big_float_range.values, list(np.linspace(-300.57, np.pi*4000)))
+        self.assertListEqual(self.categorical.values, ["a","b","c","d","e","f","g","h"])
+        self.assertListEqual(self.bool.values, [True, False])
+
+
     def test_rand_error(self):
         with self.assertRaises(ValueError):
             self.intger_range.get_random_value(definite_list=True)
@@ -72,7 +86,7 @@ class NumberRangeTest(unittest.TestCase):
 
         number_range_logspace = FloatRange(-1, 1, num=50, range_type='logspace')
         number_range_logspace.transform()
-        np.testing.assert_array_almost_equal(number_range_logspace.values,  np.logspace(-1, 1, num=50).tolist())
+        np.testing.assert_array_almost_equal(number_range_logspace.values,  np.logspace(-1, 1, num=50))
 
         # error tests
         with self.assertRaises(ValueError):
@@ -86,6 +100,10 @@ class NumberRangeTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             IntegerRange(start=self.start, stop=self.end, range_type="ownspace")
 
+    def test_false_range_type(self):
+        with self.assertRaises(ValueError):
+            float_range = FloatRange(1.0, 5.2, range_type='normal_distributed')
+            float_range.transform()
 
 class HyperparameterOtherTest(unittest.TestCase):
 

--- a/photonai/test/optimization_tests/smac/smac_test.py
+++ b/photonai/test/optimization_tests/smac/smac_test.py
@@ -27,6 +27,8 @@ try:
     from smac.tae.execute_func import ExecuteTAFuncDict
     from smac.scenario.scenario import Scenario
     from smac.facade.smac_bo_facade import SMAC4BO
+    from smac.facade.smac_hpo_facade import SMAC4HPO
+    from smac.facade.smac_ac_facade import SMAC4AC
 
     found = True
 except ModuleNotFoundError:
@@ -47,123 +49,68 @@ if not found:
                 smac = SMACOptimizer()
 
 else:
-
-    class SMACOptimizerWithRequirementsTest(GridSearchOptimizerTest):
-
-        def setUp(self):
-            """
-            Set up for SmacOptimizer.
-            """
-            self.pipeline_elements = [PipelineElement("StandardScaler"),
-                                      PipelineElement('PCA', hyperparameters={'n_components': IntegerRange(5, 20)},
-                                                      test_disabled=True),
-                                      PipelineElement("SVC")]
-            self.optimizer = SMACOptimizer()
-
-        def test_all_functions_available(self):
-            """
-            Test existence of functions and parameters ->  .ask() .tell() .prepare()
-            Has to pass cause tell() got additional attribute runtime.
-            """
-            pass
-
-        def test_ask(self):
-            """
-            Test general functionality of .ask(). Not implemented yet.
-            """
-            pass
-
-        def test_ask_advanced(self):
-            """
-            Test advanced functionality of .ask(). Not implemented yet.
-            """
-            pass
-
-        def test_all_attributes_available(self):
-            pass
-
-
-
     class Smac3IntegrationTest(unittest.TestCase):
 
         def setUp(self):
             self.s_split = ShuffleSplit(n_splits=5, test_size=0.2, random_state=42)
 
-            self.time_limit = 60*5
+            self.time_limit = 60*2
 
             settings = OutputSettings(project_folder='./tmp/')
 
             self.smac_helper = {"data": None, "initial_runs": None}
 
-
-            # Build Configuration Space which defines all parameters and their ranges
-            cs = ConfigurationSpace()
-            # We define a few possible types of SVM-kernels and add them as "kernel" to our cs
-            n_components = UniformIntegerHyperparameter("PCA__n_components", 5, 30)  # , default_value=5)
-            cs.add_hyperparameter(n_components)
-            kernel = CategoricalHyperparameter("SVC__kernel", ["rbf", 'poly'])  #, default_value="linear")
-            cs.add_hyperparameter(kernel)
-            c = UniformFloatHyperparameter("SVC__C", 0.5, 200)  #, default_value=1)
-            cs.add_hyperparameter(c)
             # Scenario object
-            scenario_dict = {"run_obj": "quality",  # we optimize quality (alternatively runtime)
-                                 #"runcount-limit": 100,  # maximum function evaluations
-                                 "deterministic": "true",
-                                 "cs": cs,
-                                 #"shared_model": "false",
-                                 "wallclock_limit": self.time_limit
-                                 }
+            scenario_dict = {"run_obj": "quality",
+                             "deterministic": "true",
+                             "wallclock_limit": self.time_limit
+                            }
 
             # DESIGN YOUR PIPELINE
-            self.pipe = Hyperpipe('basic_svm_pipe',  # the name of your pipeline
-                                optimizer='smac',  # which optimizer PHOTON shall use
-                                optimizer_params={'facade': 'SMAC4BO', 'scenario_dict': scenario_dict, 'rng': 42, 'smac_helper': self.smac_helper},
-                                metrics=['accuracy'],
-                                # the performance metrics of your interest
-                                random_seed = 42,
-                                best_config_metric='accuracy',
-                                inner_cv=ShuffleSplit(n_splits=5, test_size=0.2, random_state=42),
-                                verbosity=1,
-                                output_settings=settings)
+            self.pipe = Hyperpipe('basic_svm_pipe',
+                                  optimizer='smac',  # which optimizer PHOTON shall use
+                                  optimizer_params={'facade': SMAC4BO,
+                                                    'scenario_dict': scenario_dict,
+                                                    'rng': 42,
+                                                    'smac_helper': self.smac_helper},
+                                  metrics=['accuracy'],
+                                  random_seed = 42,
+                                  best_config_metric='accuracy',
+                                  inner_cv=ShuffleSplit(n_splits=5, test_size=0.2, random_state=42),
+                                  verbosity=0,
+                                  output_settings=settings)
 
         def simple_classification(self):
             dataset = fetch_olivetti_faces(download_if_missing=True)
             self.X = dataset["data"]
             self.y = dataset["target"]
-            #self.X, self.y = load_digits(n_class=2, return_X_y=True)
             return self.X, self.y
 
-        def test_against_smac(self):
+        def test_against_smac_initial_design(self):
             # PHOTON implementation
             self.pipe.add(PipelineElement('StandardScaler'))
-            # then do feature selection using a PCA, specify which values to try in the hyperparameter search
             self.pipe += PipelineElement('PCA', hyperparameters={'n_components': IntegerRange(5, 30)})
-            # engage and optimize the good old SVM for Classification
             self.pipe += PipelineElement('SVC', hyperparameters={'kernel': Categorical(["rbf", 'poly']),
                                                                  'C': FloatRange(0.5, 200)}, gamma='auto')
-
             self.X, self.y = self.simple_classification()
             self.pipe.fit(self.X, self.y)
 
 
-            # AUTO ML implementation direct
+            # direct AUTO ML implementation
 
             # Build Configuration Space which defines all parameters and their ranges
             cs = ConfigurationSpace()
-            # We define a few possible types of SVM-kernels and add them as "kernel" to our cs
-            n_components = UniformIntegerHyperparameter("PCA__n_components", 5, 30)  # , default_value=5)
+            n_components = UniformIntegerHyperparameter("PCA__n_components", 5, 30)
             cs.add_hyperparameter(n_components)
-            kernel = CategoricalHyperparameter("SVC__kernel", ["rbf", 'poly'])  #, default_value="linear")
+            kernel = CategoricalHyperparameter("SVC__kernel", ["rbf", 'poly'])
             cs.add_hyperparameter(kernel)
-            c = UniformFloatHyperparameter("SVC__C", 0.5, 200)  #, default_value=1)
+            c = UniformFloatHyperparameter("SVC__C", 0.5, 200)
             cs.add_hyperparameter(c)
 
             # Scenario object
-            scenario = Scenario({"run_obj": "quality",  # we optimize quality (alternatively runtime)
-                                 #"runcount-limit": 100,  # maximum function evaluations
-                                 "cs": cs,  # configuration space
+            scenario = Scenario({"run_obj": "quality",
+                                 "cs": cs,
                                  "deterministic": "true",
-                                 #"shared_model": "false",
                                  "wallclock_limit": self.time_limit,
                                  "limit_resources" : False
                                  })
@@ -216,10 +163,10 @@ else:
             bias_term = np.mean([abs(y_ax_original_inc[t]-y_ax_photon_inc[t]) for t in range(len(y_ax_photon_inc))])
             photon_pairing = [sum(values)/len(values)-bias_term for values in neighbours(y_ax_photon)]
             counter = 0
-            for i,x in enumerate(x_ax):
-                if abs(original_pairing[i]-photon_pairing[i]) > 0.07:
+            for i in range(24):
+                if abs(y_ax_original[i]-y_ax_photon[i]) > 0.1:
                     counter +=1
-            self.assertLessEqual(counter/len(x_ax), 0.15)
+            self.assertLessEqual(counter/24, 0.05)
 
         def objective_function(self, cfg):
             cfg = {k: cfg[k] for k in cfg if cfg[k]}
@@ -232,8 +179,30 @@ else:
             X, Xx, y, yy = train_test_split(self.X, self.y, test_size = 0.2, random_state = 42)
 
             metric = cross_validate(my_pipe,
-                                     X, y,
-                                     cv=ShuffleSplit(n_splits=5, test_size=0.2, random_state=42),
-                                     scoring=make_scorer(accuracy_score, greater_is_better=True)) #, scoring=my_pipe.predict)
+                                    X, y,
+                                    cv=ShuffleSplit(n_splits=5, test_size=0.2, random_state=42),
+                                    scoring=make_scorer(accuracy_score, greater_is_better=True)) #, scoring=my_pipe.predict)
             print("run")
             return 1-np.mean(metric["test_score"])
+
+
+        def test_facade(self):
+            config_space = ConfigurationSpace()
+            n_components = UniformIntegerHyperparameter("PCA__n_components", 5, 30)
+            config_space.add_hyperparameter(n_components)
+            scenario_dict = {"run_obj": "quality",
+                             "deterministic": "true",
+                             "cs":config_space,
+                             "wallclock_limit": 60
+                             }
+
+            with self.assertRaises(ValueError):
+                SMACOptimizer(facade="SMAC4BOO", scenario_dict=scenario_dict)
+
+            with self.assertRaises(ValueError):
+                facade = SMAC4BO(scenario = Scenario(scenario_dict))
+                SMACOptimizer(facade=facade, scenario_dict=scenario_dict)
+
+            facades = ["SMAC4BO", SMAC4BO, "SMAC4AC", SMAC4AC, "SMAC4HPO", SMAC4HPO]
+            for facade in facades:
+                SMACOptimizer(facade=facade, scenario_dict=scenario_dict)

--- a/photonai/test/optimization_tests/smac/smac_test.py
+++ b/photonai/test/optimization_tests/smac/smac_test.py
@@ -26,7 +26,7 @@ try:
     # Import SMAC-utilities
     from smac.tae.execute_func import ExecuteTAFuncDict
     from smac.scenario.scenario import Scenario
-    from smac.facade.smac_ac_facade import SMAC4AC
+    from smac.facade.smac_bo_facade import SMAC4BO
 
     found = True
 except ModuleNotFoundError:
@@ -35,7 +35,19 @@ except ModuleNotFoundError:
 
 warnings.filterwarnings("ignore")
 
-if found:
+if not found:
+    class SMACOptimizerWithoutRequirementsTest(unittest.TestCase):
+
+        def test_imports(self):
+            """
+            Test for ModuleNotFoundError (requirements.txt).
+            """
+            with self.assertRaises(ModuleNotFoundError):
+                from photonai.optimization.smac.smac import SMACOptimizer
+                smac = SMACOptimizer()
+
+else:
+
     class SMACOptimizerWithRequirementsTest(GridSearchOptimizerTest):
 
         def setUp(self):
@@ -67,168 +79,161 @@ if found:
             """
             pass
 
-else:
-    class SMACOptimizerWithoutRequirementsTest(unittest.TestCase):
-
-        def test_imports(self):
-            """
-            Test for ModuleNotFoundError (requirements.txt).
-            """
-            with self.assertRaises(ModuleNotFoundError):
-                from photonai.optimization.smac.smac import SMACOptimizer
+        def test_all_attributes_available(self):
+            pass
 
 
-class Smac3IntegrationTest(unittest.TestCase):
 
-    def setUp(self):
-        self.s_split = ShuffleSplit(n_splits=5, test_size=0.2, random_state=42)
+    class Smac3IntegrationTest(unittest.TestCase):
 
-        self.time_limit = 60*40
+        def setUp(self):
+            self.s_split = ShuffleSplit(n_splits=5, test_size=0.2, random_state=42)
 
-        settings = OutputSettings(project_folder='./tmp/')
+            self.time_limit = 60*5
 
-        self.smac_helper = {"data": None, "initial_runs": None}
+            settings = OutputSettings(project_folder='./tmp/')
 
-
-        # Build Configuration Space which defines all parameters and their ranges
-        cs = ConfigurationSpace()
-        # We define a few possible types of SVM-kernels and add them as "kernel" to our cs
-        n_components = UniformIntegerHyperparameter("PCA__n_components", 5, 30)  # , default_value=5)
-        cs.add_hyperparameter(n_components)
-        kernel = CategoricalHyperparameter("SVC__kernel", ["rbf", 'poly'])  #, default_value="linear")
-        cs.add_hyperparameter(kernel)
-        c = UniformFloatHyperparameter("SVC__C", 0.5, 200)  #, default_value=1)
-        cs.add_hyperparameter(c)
-        # Scenario object
-        scenario_dict = {"run_obj": "quality",  # we optimize quality (alternatively runtime)
-                             #"runcount-limit": 100,  # maximum function evaluations
-                             "deterministic": "true",
-                             "cs": cs,
-                             #"shared_model": "false",
-                             "wallclock_limit": self.time_limit
-                             }
-
-        # DESIGN YOUR PIPELINE
-        self.pipe = Hyperpipe('basic_svm_pipe',  # the name of your pipeline
-                            optimizer='smac',  # which optimizer PHOTON shall use
-                            optimizer_params={'scenario_dict': scenario_dict, 'rng': 42, 'smac_helper': self.smac_helper},
-                            metrics=['accuracy'],
-                            # the performance metrics of your interest
-                            random_seed = 42,
-                            best_config_metric='accuracy',
-                            inner_cv = None,  # test each configuration ten times respectively,
-                            verbosity=1,
-                            output_settings=settings)
-
-    def simple_classification(self):
-        dataset = fetch_olivetti_faces(download_if_missing=True)
-        self.X = dataset["data"]
-        self.y = dataset["target"]
-        #self.X, self.y = load_digits(n_class=2, return_X_y=True)
-        return self.X, self.y
-
-    def test_against_smac(self):
-        # PHOTON implementation
-        self.pipe.add(PipelineElement('StandardScaler'))
-        # then do feature selection using a PCA, specify which values to try in the hyperparameter search
-        self.pipe += PipelineElement('PCA', hyperparameters={'n_components': IntegerRange(5, 30)})
-        # engage and optimize the good old SVM for Classification
-        self.pipe += PipelineElement('SVC', hyperparameters={'kernel': Categorical(["rbf", 'poly']),
-                                                             'C': FloatRange(0.5, 200)}, gamma='auto')
-
-        self.X, self.y = self.simple_classification()
-        self.pipe.fit(self.X, self.y)
+            self.smac_helper = {"data": None, "initial_runs": None}
 
 
-        # AUTO ML implementation direct
+            # Build Configuration Space which defines all parameters and their ranges
+            cs = ConfigurationSpace()
+            # We define a few possible types of SVM-kernels and add them as "kernel" to our cs
+            n_components = UniformIntegerHyperparameter("PCA__n_components", 5, 30)  # , default_value=5)
+            cs.add_hyperparameter(n_components)
+            kernel = CategoricalHyperparameter("SVC__kernel", ["rbf", 'poly'])  #, default_value="linear")
+            cs.add_hyperparameter(kernel)
+            c = UniformFloatHyperparameter("SVC__C", 0.5, 200)  #, default_value=1)
+            cs.add_hyperparameter(c)
+            # Scenario object
+            scenario_dict = {"run_obj": "quality",  # we optimize quality (alternatively runtime)
+                                 #"runcount-limit": 100,  # maximum function evaluations
+                                 "deterministic": "true",
+                                 "cs": cs,
+                                 #"shared_model": "false",
+                                 "wallclock_limit": self.time_limit
+                                 }
 
-        # Build Configuration Space which defines all parameters and their ranges
-        cs = ConfigurationSpace()
-        # We define a few possible types of SVM-kernels and add them as "kernel" to our cs
-        n_components = UniformIntegerHyperparameter("PCA__n_components", 5, 30)  # , default_value=5)
-        cs.add_hyperparameter(n_components)
-        kernel = CategoricalHyperparameter("SVC__kernel", ["rbf", 'poly'])  #, default_value="linear")
-        cs.add_hyperparameter(kernel)
-        c = UniformFloatHyperparameter("SVC__C", 0.5, 200)  #, default_value=1)
-        cs.add_hyperparameter(c)
+            # DESIGN YOUR PIPELINE
+            self.pipe = Hyperpipe('basic_svm_pipe',  # the name of your pipeline
+                                optimizer='smac',  # which optimizer PHOTON shall use
+                                optimizer_params={'facade': 'SMAC4BO', 'scenario_dict': scenario_dict, 'rng': 42, 'smac_helper': self.smac_helper},
+                                metrics=['accuracy'],
+                                # the performance metrics of your interest
+                                random_seed = 42,
+                                best_config_metric='accuracy',
+                                inner_cv=ShuffleSplit(n_splits=5, test_size=0.2, random_state=42),
+                                verbosity=1,
+                                output_settings=settings)
 
-        # Scenario object
-        scenario = Scenario({"run_obj": "quality",  # we optimize quality (alternatively runtime)
-                             #"runcount-limit": 100,  # maximum function evaluations
-                             "cs": cs,  # configuration space
-                             "deterministic": "true",
-                             #"shared_model": "false",
-                             "wallclock_limit": self.time_limit,
-                             "limit_resources" : False
-                             })
+        def simple_classification(self):
+            dataset = fetch_olivetti_faces(download_if_missing=True)
+            self.X = dataset["data"]
+            self.y = dataset["target"]
+            #self.X, self.y = load_digits(n_class=2, return_X_y=True)
+            return self.X, self.y
 
-        # Optimize, using a SMAC-object
-        print("Optimizing! Depending on your machine, this might take a few minutes.")
-        smac = SMAC4AC(scenario=scenario, rng=42,
-                       tae_runner=self.objective_function)
+        def test_against_smac(self):
+            # PHOTON implementation
+            self.pipe.add(PipelineElement('StandardScaler'))
+            # then do feature selection using a PCA, specify which values to try in the hyperparameter search
+            self.pipe += PipelineElement('PCA', hyperparameters={'n_components': IntegerRange(5, 30)})
+            # engage and optimize the good old SVM for Classification
+            self.pipe += PipelineElement('SVC', hyperparameters={'kernel': Categorical(["rbf", 'poly']),
+                                                                 'C': FloatRange(0.5, 200)}, gamma='auto')
 
-        self.helper0 = smac
-
-        incumbent = smac.optimize()
-
-        inc_value = self.objective_function(incumbent)
-
-        print(incumbent)
-        print(inc_value)
-
-        runhistory_photon = self.smac_helper["data"].solver.runhistory
-        runhistory_original = smac.solver.runhistory
-
-
-        x_ax = range(1, min(len(runhistory_original._cost_per_config.keys()), len(runhistory_photon._cost_per_config.keys()))+1)
-        y_ax_original = [runhistory_original._cost_per_config[tmp] for tmp in x_ax]
-        y_ax_photon = [runhistory_photon._cost_per_config[tmp] for tmp in x_ax]
-
-        y_ax_original_inc = [min(y_ax_original[:tmp+1]) for tmp in x_ax]
-        y_ax_photon_inc = [min(y_ax_photon[:tmp+1]) for tmp in x_ax]
-
-        plt.figure(figsize=(10, 7))
-        plt.plot(x_ax, y_ax_original, 'g', label='Original')
-        plt.plot(x_ax, y_ax_photon, 'b', label='PHOTON')
-        plt.plot(x_ax, y_ax_photon_inc, 'r', label='PHOTON Incumbent')
-        plt.plot(x_ax, y_ax_original_inc, 'k', label='Original Incumbent')
-        plt.title('Photon Prove')
-        plt.xlabel('X')
-        plt.ylabel('Y')
-        plt.legend(loc='best')
-        plt.savefig("smac.png")
+            self.X, self.y = self.simple_classification()
+            self.pipe.fit(self.X, self.y)
 
 
-        def neighbours(items, fill=None):
-            before = itertools.chain([fill], items)
-            after = itertools.chain(items, [fill])  # You could use itertools.zip_longest() later instead.
-            next(after)
-            for a, b, c in zip(before, items, after):
-                yield [value for value in (a, b, c) if value is not fill]
+            # AUTO ML implementation direct
 
-        print("---------------")
-        original_pairing = [sum(values)/len(values) for values in neighbours(y_ax_original)]
-        bias_term = np.mean([abs(y_ax_original_inc[t]-y_ax_photon_inc[t]) for t in range(len(y_ax_photon_inc))])
-        photon_pairing = [sum(values)/len(values)-bias_term for values in neighbours(y_ax_photon)]
-        counter = 0
-        for i,x in enumerate(x_ax):
-            if abs(original_pairing[i]-photon_pairing[i]) > 0.07:
-                counter +=1
-        self.assertLessEqual(counter/len(x_ax), 0.15)
+            # Build Configuration Space which defines all parameters and their ranges
+            cs = ConfigurationSpace()
+            # We define a few possible types of SVM-kernels and add them as "kernel" to our cs
+            n_components = UniformIntegerHyperparameter("PCA__n_components", 5, 30)  # , default_value=5)
+            cs.add_hyperparameter(n_components)
+            kernel = CategoricalHyperparameter("SVC__kernel", ["rbf", 'poly'])  #, default_value="linear")
+            cs.add_hyperparameter(kernel)
+            c = UniformFloatHyperparameter("SVC__C", 0.5, 200)  #, default_value=1)
+            cs.add_hyperparameter(c)
 
-    def objective_function(self, cfg):
-        cfg = {k: cfg[k] for k in cfg if cfg[k]}
-        sc = PipelineElement("StandardScaler", {})
-        pca = PipelineElement("PCA", {}, random_state=42)
-        svc = PipelineElement("SVC", {}, random_state=42, gamma='auto')
-        my_pipe = PhotonPipeline([('StandardScaler', sc), ('PCA', pca), ('SVC', svc)])
-        my_pipe.set_params(**cfg)
+            # Scenario object
+            scenario = Scenario({"run_obj": "quality",  # we optimize quality (alternatively runtime)
+                                 #"runcount-limit": 100,  # maximum function evaluations
+                                 "cs": cs,  # configuration space
+                                 "deterministic": "true",
+                                 #"shared_model": "false",
+                                 "wallclock_limit": self.time_limit,
+                                 "limit_resources" : False
+                                 })
 
-        X, Xx, y, yy = train_test_split(self.X, self.y, test_size = 0.2, random_state = 42)
+            # Optimize, using a SMAC-object
+            print("Optimizing! Depending on your machine, this might take a few minutes.")
+            smac = SMAC4BO(scenario=scenario, rng=42,
+                           tae_runner=self.objective_function)
 
-        metric = cross_validate(my_pipe,
-                                 X, y,
-                                 cv=ShuffleSplit(n_splits=5, test_size=0.2, random_state=42),
-                                 scoring=make_scorer(accuracy_score, greater_is_better=True)) #, scoring=my_pipe.predict)
-        print("run")
-        return 1-np.mean(metric["test_score"])
+            self.helper0 = smac
+
+            incumbent = smac.optimize()
+
+            inc_value = self.objective_function(incumbent)
+
+
+            runhistory_photon = self.smac_helper["data"].solver.runhistory
+            runhistory_original = smac.solver.runhistory
+
+
+            x_ax = range(1, min(len(runhistory_original._cost_per_config.keys()), len(runhistory_photon._cost_per_config.keys()))+1)
+            y_ax_original = [runhistory_original._cost_per_config[tmp] for tmp in x_ax]
+            y_ax_photon = [runhistory_photon._cost_per_config[tmp] for tmp in x_ax]
+
+            y_ax_original_inc = [min(y_ax_original[:tmp+1]) for tmp in x_ax]
+            y_ax_photon_inc = [min(y_ax_photon[:tmp+1]) for tmp in x_ax]
+
+            plot = False
+            if plot:
+                plt.figure(figsize=(10, 7))
+                plt.plot(x_ax, y_ax_original, 'g', label='Original')
+                plt.plot(x_ax, y_ax_photon, 'b', label='PHOTON')
+                plt.plot(x_ax, y_ax_photon_inc, 'r', label='PHOTON Incumbent')
+                plt.plot(x_ax, y_ax_original_inc, 'k', label='Original Incumbent')
+                plt.title('Photon Prove')
+                plt.xlabel('X')
+                plt.ylabel('Y')
+                plt.legend(loc='best')
+                plt.savefig("smac.png")
+
+
+            def neighbours(items, fill=None):
+                before = itertools.chain([fill], items)
+                after = itertools.chain(items, [fill])  # You could use itertools.zip_longest() later instead.
+                next(after)
+                for a, b, c in zip(before, items, after):
+                    yield [value for value in (a, b, c) if value is not fill]
+
+            original_pairing = [sum(values)/len(values) for values in neighbours(y_ax_original)]
+            bias_term = np.mean([abs(y_ax_original_inc[t]-y_ax_photon_inc[t]) for t in range(len(y_ax_photon_inc))])
+            photon_pairing = [sum(values)/len(values)-bias_term for values in neighbours(y_ax_photon)]
+            counter = 0
+            for i,x in enumerate(x_ax):
+                if abs(original_pairing[i]-photon_pairing[i]) > 0.07:
+                    counter +=1
+            self.assertLessEqual(counter/len(x_ax), 0.15)
+
+        def objective_function(self, cfg):
+            cfg = {k: cfg[k] for k in cfg if cfg[k]}
+            sc = PipelineElement("StandardScaler", {})
+            pca = PipelineElement("PCA", {}, random_state=42)
+            svc = PipelineElement("SVC", {}, random_state=42, gamma='auto')
+            my_pipe = PhotonPipeline([('StandardScaler', sc), ('PCA', pca), ('SVC', svc)])
+            my_pipe.set_params(**cfg)
+
+            X, Xx, y, yy = train_test_split(self.X, self.y, test_size = 0.2, random_state = 42)
+
+            metric = cross_validate(my_pipe,
+                                     X, y,
+                                     cv=ShuffleSplit(n_splits=5, test_size=0.2, random_state=42),
+                                     scoring=make_scorer(accuracy_score, greater_is_better=True)) #, scoring=my_pipe.predict)
+            print("run")
+            return 1-np.mean(metric["test_score"])


### PR DESCRIPTION
**Some fixes for PHOTON optimization.** 

add comments and pep8 standards.

hyperparameter:
> FloatRange default: range -> linspace
> FloatRange default: np.float32 -> np.float64
> NumberRange add support for more datatypes
> add tests

smac:
> add facade param
> adjust smac tests

To discuss:
- FloatRange is now default linspace. 
  maybe warning when FloatRange.max >> FloatRange.min ?
- For later: Adding conditions like hyperparameter a only if b like svm kernels and their settings
   or PHOTON.Switch? PHOTONs SMAC version only adds conditions for the Switch.
