### PR TITLE
Bugfix/backmapping

### DIFF
--- a/photonai/processing/results_handler.py
+++ b/photonai/processing/results_handler.py
@@ -758,8 +758,10 @@ class ResultsHandler:
 
     def save_backmapping(self, filename: str, backmapping):
         try:
+            if isinstance(backmapping, list):
+                backmapping = np.asarray(backmapping)
             if isinstance(backmapping, np.ndarray):
-                if len(backmapping) > 1000:
+                if backmapping.size > 1000:
                     np.savez(os.path.join(self.output_settings.results_folder, filename + '.npz'), backmapping)
                 else:
                     np.savetxt(os.path.join(self.output_settings.results_folder, filename + '.csv'), backmapping, delimiter=',')


### PR DESCRIPTION
Pretty simply and short fix. Only problem was that we save a .csv file for back mapped features if we have less than 1000 features. In our unit test however, we expect a .npz file which therefore didn't exist.
I've fixed that and created two separate tests for .npz and .csv files.
I also convert a list of features (if some method returns a list instead of a numpy array when calling inverse_transform) to a numpy array before saving it. Until now we were saving a pickle file whenever we get a list output.