### PR TITLE
Handle of warnings and optimization adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![PHOTON LOGO](http://www.photon-ai.com/static/img/photon/photon-logo-github.png "PHOTON Logo")
 
 [![Build Status](https://travis-ci.com/wwu-mmll/photonai.svg?branch=master)](https://travis-ci.com/wwu-mmll/photonai)
-[![Coverage Status](https://coveralls.io/repos/github/wwu-mmll/photonai/badge.svg?branch=develop)](https://coveralls.io/github/wwu-mmll/photonai?branch=develop)
+[![Coverage Status](https://coveralls.io/repos/github/wwu-mmll/photonai/badge.svg?branch=master)](https://coveralls.io/github/wwu-mmll/photonai?branch=master)
 ![Github Contributors](https://img.shields.io/github/contributors-anon/wwu-mmll/photonai?color=blue)
 ![Github Commits](https://img.shields.io/github/commit-activity/m/wwu-mmll/photonai)
 ![PyPI Version](https://img.shields.io/pypi/v/photonai?color=brightgreen)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Build Status](https://travis-ci.com/wwu-mmll/photonai.svg?branch=master)](https://travis-ci.com/wwu-mmll/photonai)
 [![Coverage Status](https://coveralls.io/repos/github/wwu-mmll/photonai/badge.svg?branch=master)](https://coveralls.io/github/wwu-mmll/photonai?branch=master)
-![Github Contributors](https://img.shields.io/github/contributors-anon/wwu-mmll/photonai?color=blue)
-![Github Commits](https://img.shields.io/github/commit-activity/m/wwu-mmll/photonai)
-![PyPI Version](https://img.shields.io/pypi/v/photonai?color=brightgreen)
-![License](https://img.shields.io/github/license/wwu-mmll/photonai)
+[![Github Contributors](https://img.shields.io/github/contributors-anon/wwu-mmll/photonai?color=blue)](https://github.com/wwu-mmll/photonai/graphs/contributors)
+[![Github Commits](https://img.shields.io/github/commit-activity/m/wwu-mmll/photonai)](https://github.com/wwu-mmll/photonai/commits/master)
+[![PyPI Version](https://img.shields.io/pypi/v/photonai?color=brightgreen)](https://pypi.org/project/photonai/)
+[![License](https://img.shields.io/github/license/wwu-mmll/photonai)](https://github.com/wwu-mmll/photonai/blob/master/LICENSE)
 ![Twitter URL](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Ftwitter.com%2Fwwu_mmll)
 
 #### PHOTONAI is a high level python API for designing and optimizing machine learning pipelines.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Github Commits](https://img.shields.io/github/commit-activity/m/wwu-mmll/photonai)](https://github.com/wwu-mmll/photonai/commits/master)
 [![PyPI Version](https://img.shields.io/pypi/v/photonai?color=brightgreen)](https://pypi.org/project/photonai/)
 [![License](https://img.shields.io/github/license/wwu-mmll/photonai)](https://github.com/wwu-mmll/photonai/blob/master/LICENSE)
-![Twitter URL](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Ftwitter.com%2Fwwu_mmll)
+[![Twitter URL](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Ftwitter.com%2Fwwu_mmll)](https://twitter.com/wwu_mmll)
 
 #### PHOTONAI is a high level python API for designing and optimizing machine learning pipelines.
 
@@ -23,9 +23,9 @@ state-of-the-art machine learning toolboxes,
  hyperparameter optimization strategies.  
 
 For a detailed description, 
-###[Visit our Website and Read the Documentation](https://www.photon-ai.com) 
+__[visit our website and read the documentation](https://www.photon-ai.com)__
 
-or you can read a prolongued introduction on [Arxiv](https://arxiv.org/abs/2002.05426)
+or you can read a prolonged introduction on [Arxiv](https://arxiv.org/abs/2002.05426)
 
 
 

--- a/photonai/base/hyperpipe.py
+++ b/photonai/base/hyperpipe.py
@@ -12,6 +12,7 @@ import zipfile
 import json
 from copy import deepcopy
 from typing import Optional, List, Union
+import warnings
 
 import dask
 import numpy as np
@@ -488,7 +489,7 @@ class Hyperpipe(BaseEstimator):
 
                     self.best_config_metric = self.best_config_metric[0]
                     logger.warning(warning_text)
-                    raise Warning(warning_text)
+                    warnings.warn(warning_text)
                 elif not isinstance(self.best_config_metric, str):
                     self.best_config_metric = Scorer.register_custom_metric(self.best_config_metric)
 
@@ -516,7 +517,7 @@ class Hyperpipe(BaseEstimator):
                 warning_text = "No best config metric was given, so PHOTON chose the first in the list of metrics as " \
                                "criteria for choosing the best configuration."
                 logger.warning(warning_text)
-                raise Warning(warning_text)
+                warnings.warn(warning_text)
 
         def get_optimizer(self):
             if isinstance(self.optimizer_input_str, str):
@@ -539,7 +540,9 @@ class Hyperpipe(BaseEstimator):
             list_of_non_failed_configs = [conf for conf in tested_configs if not conf.config_failed]
 
             if len(list_of_non_failed_configs) == 0:
-                raise Warning("No Configs found which did not fail.")
+                msg = "No Configs found which did not fail."
+                logger.warning(msg)
+                warnings.warn(msg)
             try:
 
                 if len(list_of_non_failed_configs) == 1:
@@ -706,7 +709,9 @@ class Hyperpipe(BaseEstimator):
             json_transformer = JsonTransformer()
             json_transformer.to_json_file(self, self.output_settings.results_folder+"/hyperpipe_config.json")
         except:
-            logger.warning("JsonTransformer was unable to create the .json file.")
+            msg = "JsonTransformer was unable to create the .json file."
+            logger.warning(msg)
+            warnings.warn(msg)
 
         # add flowchart to results
         try:
@@ -876,7 +881,7 @@ class Hyperpipe(BaseEstimator):
                         warning_text = "y has been automatically squeezed. If this is not your intention, block this " \
                                        "with Hyperpipe(allow_multidim_targets = True"
                         logger.warning(warning_text)
-                        raise Warning(warning_text)
+                        warnings.warn(warning_text)
                     else:
                         raise ValueError("Target is not one-dimensional. Multidimensional targets can cause problems"
                                          "with sklearn metrics. Please override with "
@@ -1440,7 +1445,9 @@ class PhotonModelPersistor:
         zip_file = folder + '.photon'
 
         if os.path.exists(folder):
-            logger.warning('The file you specified already exists as a folder.')
+            msg = 'The file you specified already exists as a folder.'
+            logger.warning(msg)
+            warnings.warn(msg)
         else:
             os.makedirs(folder)
 

--- a/photonai/base/hyperpipe.py
+++ b/photonai/base/hyperpipe.py
@@ -22,8 +22,7 @@ from dask.distributed import Client
 from sklearn.base import BaseEstimator
 from sklearn.dummy import DummyClassifier, DummyRegressor
 import joblib
-from sklearn.model_selection._split import BaseCrossValidator
-from sklearn.model_selection import KFold
+from sklearn.model_selection._split import BaseCrossValidator, BaseShuffleSplit, _RepeatedSplits
 
 from photonai.__init__ import __version__
 from photonai.base.cache_manager import CacheManager
@@ -195,10 +194,10 @@ class Hyperpipe(BaseEstimator):
     * `name` [str]:
         Name of hyperpipe instance
 
-    * `inner_cv` [BaseCrossValidator]:
+    * `inner_cv` Union[BaseCrossValidator, BaseShuffleSplit, _RepeatedSplits]:
         Cross validation strategy to test hyperparameter configurations, generates the validation set
 
-    * `outer_cv` [BaseCrossValidator]:
+    * `outer_cv` Union[BaseCrossValidator, BaseShuffleSplit, _RepeatedSplits]:
         Cross validation strategy to use for the hyperparameter search itself, generates the test set
 
     * `optimizer` [str or object, default="grid_search"]:
@@ -298,7 +297,7 @@ class Hyperpipe(BaseEstimator):
    """
 
     def __init__(self, name,
-                 inner_cv: BaseCrossValidator = None,
+                 inner_cv: Union[BaseCrossValidator, BaseShuffleSplit, _RepeatedSplits] = None,
                  outer_cv = None,
                  optimizer: str = 'grid_search',
                  optimizer_params: dict = None,

--- a/photonai/base/photon_elements.py
+++ b/photonai/base/photon_elements.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 import dask
 from dask.distributed import Client
 import numpy as np
+import warnings
 from sklearn.base import BaseEstimator
 from sklearn.model_selection._search import ParameterGrid
 
@@ -222,6 +223,7 @@ class PipelineElement(BaseEstimator):
         if already_existing_element_with_that_name > 0:
             error_msg = "Already added a pipeline element with the name " + pipe_element.name + " to " + self.name
             logger.warning(error_msg)
+            warnings.warn(error_msg)
 
             # check for other items that have been renamed
             nr_of_existing_elements_with_that_name = len([i for i in self.elements if i.name.startswith(pipe_element.name)])
@@ -229,8 +231,9 @@ class PipelineElement(BaseEstimator):
             while len([i for i in self.elements if i.name == new_name]) > 0:
                 nr_of_existing_elements_with_that_name += 1
                 new_name = pipe_element.name + str(nr_of_existing_elements_with_that_name + 1)
-
-            logger.warning("Renaming " + pipe_element.name + " in " + self.name + " to " + new_name + " in " + self.name)
+            msg = "Renaming " + pipe_element.name + " in " + self.name + " to " + new_name + " in " + self.name
+            logger.warning(msg)
+            warnings.warn(msg)
             pipe_element.name = new_name
 
         self.elements.append(pipe_element)
@@ -350,9 +353,9 @@ class PipelineElement(BaseEstimator):
 
     def __batch_predict(self, delegate, X, **kwargs):
         if not isinstance(X, list) and not isinstance(X, np.ndarray):
-            warning = "Cannot do batching on a single entity."
-            logger.warning(warning)
-            raise Warning(warning)
+            msg = "Cannot do batching on a single entity."
+            logger.warning(msg)
+            warnings.warn(msg)
             return delegate(X, **kwargs)
 
             # initialize return values
@@ -452,7 +455,7 @@ class PipelineElement(BaseEstimator):
         if not isinstance(X, list) and not isinstance(X, np.ndarray):
             warning = "Cannot do batching on a single entity."
             logger.warning(warning)
-            raise Warning(warning)
+            warnings.warn(warning)
             return self.__transform(X, y, **kwargs)
 
             # initialize return values
@@ -636,9 +639,10 @@ class Branch(PipelineElement):
     @staticmethod
     def sanity_check_pipeline(pipe):
         if isinstance(pipe.elements[-1][1], CallbackElement):
-            raise Warning("Last element of pipeline cannot be callback element, would be mistaken for estimator. Removing it.")
-            Logger().warn("Last element of pipeline cannot be callback element, would be mistaken for estimator. Removing it.")
-            del pipeline_steps[-1]
+            msg = "Last element of pipeline cannot be callback element, would be mistaken for estimator. Removing it."
+            logger.warning(msg)
+            warnings.warn(msg)
+            del pipe.elements[-1]
         return pipe
 
     def _prepare_pipeline(self):
@@ -745,7 +749,7 @@ class Preprocessing(Branch):
         return self
 
     def predict(self, data, **kwargs):
-        raise Warning("There is no predict function of the preprocessing pipe, it is a transformer only.")
+        warnings.warn("There is no predict function of the preprocessing pipe, it is a transformer only.")
         pass
 
     @property

--- a/photonai/modelwrapper/keras_base_estimator.py
+++ b/photonai/modelwrapper/keras_base_estimator.py
@@ -1,7 +1,10 @@
-from sklearn.base import BaseEstimator
-from photonai.photonlogger.logger import logger
+import warnings
 import keras
 import tensorflow
+from sklearn.base import BaseEstimator
+
+
+from photonai.photonlogger.logger import logger
 
 
 class KerasBaseEstimator(BaseEstimator):
@@ -59,7 +62,9 @@ class KerasBaseEstimator(BaseEstimator):
                            verbose=self.verbosity)
         else:
             # fit the model
-            logger.warning('Cannot use Keras Callbacks because of small sample size.')
+            msg = 'Cannot use Keras Callbacks because of small sample size.'
+            logger.warning(msg)
+            warnings.warn(msg)
             self.model.fit(X, y,
                            batch_size=self.nn_batch_size,
                            epochs=self.epochs,

--- a/photonai/modelwrapper/keras_base_models.py
+++ b/photonai/modelwrapper/keras_base_models.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 import keras
 from keras.utils import to_categorical
@@ -8,8 +9,8 @@ from keras.optimizers import Optimizer, Adam, RMSprop, Adadelta, Adagrad, Adamax
 from keras.activations import softmax, softplus, selu, sigmoid, softsign, hard_sigmoid, elu, relu, tanh, \
     linear, exponential
 from sklearn.base import ClassifierMixin, RegressorMixin
-from photonai.photonlogger.logger import logger
 
+from photonai.photonlogger.logger import logger
 from photonai.modelwrapper.keras_base_estimator import KerasBaseEstimator
 
 __supported_optimizers__ = {
@@ -181,7 +182,9 @@ class KerasDnnBaseModel(KerasBaseEstimator):
             else:
                 if type(value) == float:
                     self._dropout_rate = [value]*len(self.hidden_layer_sizes)
-                    logger.warning("Dropout with type float converted to type list.")
+                    msg = "Dropout with type float converted to type list."
+                    logger.warning(msg)
+                    warnings.warn(msg)
                 elif len(value) != len(self.hidden_layer_sizes):
                     raise ValueError("Dropout length missmatched layer length.")
                 else:
@@ -211,7 +214,9 @@ class KerasDnnBaseModel(KerasBaseEstimator):
                 if type(value) == str:
                     if value in __supported_activations__.keys():
                         self._activations = [value]*len(self.hidden_layer_sizes)
-                        logger.warning("activations with type str converted to type list.")
+                        msg = "activations with type str converted to type list."
+                        logger.warning(msg)
+                        warnings.warn(msg)
                     else:
                         raise ValueError(
                             "activations not supported. Please use one of: " + str(__supported_activations__.keys()))

--- a/photonai/optimization/config_grid.py
+++ b/photonai/optimization/config_grid.py
@@ -1,7 +1,7 @@
 from photonai.optimization import PhotonHyperparam, IntegerRange, FloatRange, Categorical, BooleanSwitch
 from photonai.photonlogger import logger
 from itertools import product
-import numpy as np
+import warnings
 
 
 def create_global_config_dict(pipeline_elements):
@@ -47,12 +47,12 @@ def create_global_config_grid(pipeline_elements, add_name=''):
     for i in global_hyperparameter_list:
         total_product_num = total_product_num * len(i)
     if total_product_num > threshold:
-        warn_text = 'The entire configuration grid entails more than ' + str(threshold) + ' possible configurations. ' \
-                                                                                          'This might take veeeeeeery ' \
-                                                                                          'looooong to both compute ' \
-                                                                                          'and process.'
-        logger.warning(warn_text)
-        raise Warning(warn_text)
+        msg = 'The entire configuration grid entails more than ' + str(threshold) + ' possible configurations. ' \
+                                                                                    'This might take very ' \
+                                                                                    'long to both compute ' \
+                                                                                    'and process.'
+        logger.error(msg)
+        raise ValueError(msg)
     config_list = list(product(*global_hyperparameter_list))
     config_dicts = []
     # get all configs in one

--- a/photonai/optimization/hyperparameters.py
+++ b/photonai/optimization/hyperparameters.py
@@ -1,5 +1,7 @@
-import numpy as np
+import warnings
 import random
+import numpy as np
+
 from photonai.photonlogger.logger import logger
 
 
@@ -45,9 +47,6 @@ class Categorical(PhotonHyperparam):
 
     def __getitem__(self, item):
         return self.values.__getitem__(item)
-
-    def __index__(self, obj):
-        return self.values.__index__(obj)
 
 
 class BooleanSwitch(PhotonHyperparam):
@@ -137,6 +136,7 @@ class NumberRange(PhotonHyperparam):
             warn_message = "NumberRange or one of its subclasses is empty cause np.arange " + \
                            "does not deal with start greater than stop."
             logger.warning(warn_message)
+            warnings.warn(warn_message)
 
         values = []
 
@@ -169,8 +169,8 @@ class NumberRange(PhotonHyperparam):
         except:
             msg = "PHOTON can not guarantee full mongodb support since you chose a non [np.integer, np.floating] " \
                   "subtype in NumberType.dtype."
-            logger.warn(msg)
-            raise Warning(msg)
+            logger.warning(msg)
+            warnings.warn(msg)
             self.values = values
 
     @property

--- a/photonai/optimization/performance_constraints.py
+++ b/photonai/optimization/performance_constraints.py
@@ -1,6 +1,8 @@
 from enum import Enum
 import numpy as np
 import inspect
+import warnings
+
 from photonai.processing.metrics import Scorer
 from photonai.photonlogger.logger import logger
 
@@ -82,12 +84,16 @@ class PhotonBaseConstraint:
             Can be used to evaluate if the configuration has any potential to serve the model's learning task.
         """
         if self.metric == "unknown":
-            logger.warning("The metric is not known. Please check the metric: " + self.metric + ". " +
-                        "Performance constraints are constantly True.")
+            msg = "The metric is not known. Please check the metric: " + self.metric + ". " +\
+                  "Performance constraints are constantly True."
+            logger.warning(msg)
+            warnings.warn(msg)
             return True
         if self.metric not in config_item.inner_folds[0].validation.metrics:
-            logger.warning("The metric is not calculated. Please insert " + self.metric + " to Hyperpipe.metrics. " +
-                        "Performance constraints are constantly False.")
+            msg = "The metric is not calculated. Please insert " + self.metric + " to Hyperpipe.metrics. " + \
+                  "Performance constraints are constantly False."
+            logger.warning(msg)
+            warnings.warn(msg)
             return False
         if self._greater_is_better:
             if self.strategy.name == 'first':

--- a/photonai/optimization/random_search/random_search.py
+++ b/photonai/optimization/random_search/random_search.py
@@ -11,6 +11,8 @@ class RandomSearchOptimizer(PhotonSlaveOptimizer):
     """
 
     def __init__(self, n_configurations=None, limit_in_minutes=60):
+        super(RandomSearchOptimizer, self).__init__()
+
         self.pipeline_elements = None
         self.parameter_iterable = None
         self.ask = self.next_config_generator()
@@ -29,9 +31,10 @@ class RandomSearchOptimizer(PhotonSlaveOptimizer):
             self.n_configurations = n_configurations
         self.k_configutration = 0  # use k++ until k==n: break
 
-        if not n_configurations and limit_in_minutes <= 0:
+        if self.n_configurations is None and self.limit_in_minutes is None:
             msg = "No stopping criteria for RandomSearchOptimizer."
-            logger.warning(msg)
+            logger.error(msg)
+            raise ValueError(msg)
 
     def prepare(self, pipeline_elements, maximize_metric):
         self.pipeline_elements = pipeline_elements
@@ -54,10 +57,6 @@ class RandomSearchOptimizer(PhotonSlaveOptimizer):
                 if self.k_configutration >= self.n_configurations:
                     return
 
-    def tell(self, config, performance):
-        # influence return value of next_config
-        pass
-
     def generate_config(self):
         config = {}
         for p_element in self.pipeline_elements:
@@ -67,6 +66,3 @@ class RandomSearchOptimizer(PhotonSlaveOptimizer):
                 else:
                     config[h_key] = h_value.get_random_value()
         return config
-
-
-

--- a/photonai/optimization/smac/smac.py
+++ b/photonai/optimization/smac/smac.py
@@ -106,11 +106,12 @@ class SMACOptimizer(PhotonMasterOptimizer):
         elif isinstance(hyperparam, list):
             return CategoricalHyperparameter(name, hyperparam)
         elif isinstance(hyperparam, FloatRange):
-            if hyperparam.range_type == 'linspace':
-                return UniformFloatHyperparameter(name, hyperparam.start, hyperparam.stop)
-            msg = str(hyperparam.range_type) + "in your float hyperparameter is not implemented in SMAC."
+            if hyperparam.range_type in ['linspace', 'logspace']:
+                return UniformFloatHyperparameter(name, hyperparam.start, hyperparam.stop,
+                                                  log=(hyperparam.range_type == 'logspace'))
+            msg = str(hyperparam.range_type) + "in your FloatRange is not implemented in SMAC."
             logger.error(msg)
-            raise NotImplementedError("Logspace in your float hyperparameter is not implemented in SMAC.")
+            raise NotImplementedError(msg)
         elif isinstance(hyperparam, IntegerRange):
             return UniformIntegerHyperparameter(name, hyperparam.start, hyperparam.stop)
 

--- a/photonai/optimization/smac/smac_requirements.txt
+++ b/photonai/optimization/smac/smac_requirements.txt
@@ -1,3 +1,3 @@
 configspace
-smac==0.12.1
+smac
 emcee

--- a/photonai/processing/metrics.py
+++ b/photonai/processing/metrics.py
@@ -7,9 +7,10 @@ from typing import Union, Type, Callable, Optional, Tuple, Dict
 
 import numpy as np
 from scipy.stats import spearmanr
-from photonai.photonlogger.logger import logger
+import warnings
 from sklearn.metrics import accuracy_score
 
+from photonai.photonlogger.logger import logger
 
 class Scorer(object):
     """
@@ -86,7 +87,7 @@ class Scorer(object):
                         'metrics=[(\'MetricName1\', keras.metrics.Accuracy)]. Only the first occurance of this ' \
                         'metric will be used!'
             logger.warning(warn_text)
-            raise Warning(warn_text)
+            warnings.warn(warn_text)
             return None
 
         # derive a metric function from the given object
@@ -128,13 +129,15 @@ class Scorer(object):
                 scoring_method = desired_class
                 return scoring_method
             except AttributeError as ae:
-                logger.error('ValueError: Could not find according class: '
-                               + Scorer.ELEMENT_DICTIONARY[metric])
+                msg = 'Could not find according class: ' + Scorer.ELEMENT_DICTIONARY[metric]
+                logger.error(msg)
+                raise AttributeError(msg)
         elif metric in Scorer.CUSTOM_ELEMENT_DICTIONARY:
             return Scorer.CUSTOM_ELEMENT_DICTIONARY[metric]
         else:
-            logger.error('NameError: Metric not supported right now:' + metric)
-            # raise Warning('Metric not supported right now:', metric)
+            msg = 'Metric not supported right now:' + metric
+            logger.error(msg)
+            raise NameError(msg)
             return None
 
     @staticmethod

--- a/photonai/processing/results_handler.py
+++ b/photonai/processing/results_handler.py
@@ -3,6 +3,7 @@ import itertools
 import os
 import pickle
 import pprint
+import warnings
 from typing import Union
 
 import matplotlib
@@ -18,7 +19,6 @@ from pymodm import connect
 from pymongo import DESCENDING
 from pymongo.errors import DocumentTooLarge
 from scipy.stats import sem
-from sklearn.metrics import confusion_matrix, roc_curve
 
 from photonai.photonlogger.logger import logger
 from photonai.processing.metrics import Scorer
@@ -42,7 +42,7 @@ class ResultsHandler:
             self.results = MDBHyperpipe.objects.order_by([("computation_start_time", DESCENDING)]).raw({'name': pipe_name}).first()
             warn_text = 'Found multiple hyperpipes with that name. Returning most recent one.'
             logger.warning(warn_text)
-            raise Warning(warn_text)
+            warnings.warn(warn_text)
         else:
             raise FileNotFoundError('Could not load hyperpipe from MongoDB.')
 
@@ -315,8 +315,10 @@ class ResultsHandler:
             # now do smoothing
             if isinstance(reduce_scatter_by, str):
                 if reduce_scatter_by != 'auto':
-                    logger.warning('{} is not a valid smoothing_kernel specifier. Falling back to "auto".'.format(
-                        reduce_scatter_by))
+                    msg = '{} is not a valid smoothing_kernel specifier. ' \
+                          'Falling back to "auto".'.format(reduce_scatter_by)
+                    logger.warning(msg)
+                    warnings.warn(msg)
 
                 # if auto, then calculate size of reduce_scatter_by so that 75 points on x remain
                 # smallest reduce_scatter_by should be 1

--- a/photonai/requirements.txt
+++ b/photonai/requirements.txt
@@ -1,7 +1,7 @@
-###### Requirements without Version Specifiers ######
+###### Requirements with temporary Version Specifiers ######
 numpy
 matplotlib
-scikit-learn
+scikit-learn==0.23.1
 keras
 pandas
 plotly

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ with only one line of code.
     install_requires=[
         'numpy',
         'matplotlib',
-        'scikit-learn',
+        'scikit-learn==0.23.1',
         'keras',
         'pandas',
         'plotly',

--- a/test/base_tests/test_hyperpipe.py
+++ b/test/base_tests/test_hyperpipe.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import time
 import unittest
+import warnings
 
 import numpy as np
 from sklearn.datasets import load_breast_cancer
@@ -116,11 +117,13 @@ class HyperpipeTests(PhotonBaseTest):
             hyperpipe = Hyperpipe("hp_name", inner_cv=self.inner_cv_object)
 
         # make sure that if no best config metric is given, PHOTON raises a warning
-        with self.assertRaises(Warning):
+        with warnings.catch_warnings(record=True) as w:
             hyperpipe = Hyperpipe("hp_name", inner_cv=self.inner_cv_object, metrics=["accuracy", "f1_score"])
+            assert len(w) == 1
 
-        with self.assertRaises(Warning):
+        with warnings.catch_warnings(record=True) as w:
             hyperpipe = Hyperpipe("hp_name", inner_cv=self.inner_cv_object, best_config_metric=["accuracy", "f1_score"])
+            assert len(w) == 1
 
         with self.assertRaises(NotImplementedError):
             hyperpipe = Hyperpipe("hp_name", inner_cv=self.inner_cv_object,

--- a/test/base_tests/test_hyperpipe.py
+++ b/test/base_tests/test_hyperpipe.py
@@ -533,7 +533,7 @@ class HyperpipeTests(PhotonBaseTest):
             step2 = self.sklearn_pipe.named_steps["PCA"].transform(self.__X)
         else:
             step2 = step1
-        self.assertTrue(np.array_equal(step2, self.hyperpipe.transform(self.__X)))
+        self.assertTrue(np.allclose(step2, self.hyperpipe.transform(self.__X)))
 
 
 class HyperpipeOptimizationClassTests(unittest.TestCase):

--- a/test/base_tests/test_photon_batch.py
+++ b/test/base_tests/test_photon_batch.py
@@ -1,7 +1,8 @@
 import unittest
 import numpy as np
-
+import warnings
 from sklearn.base import BaseEstimator
+
 from photonai.base import PipelineElement
 
 
@@ -33,6 +34,8 @@ class DummyBatchTransformer(BaseEstimator):
     def predict(self, X, y=None, **kwargs):
         if hasattr(X, '__iter__'):
             self.predict_count += 1
+            if not hasattr(X, 'shape'):
+                return self.predict_count
             predictions = np.ones((X.shape[0],)) * self.predict_count
             return predictions
         else:
@@ -73,13 +76,15 @@ class BatchingTests(unittest.TestCase):
         self.assertEqual(kwargs_new["animals"][0], "effa")
         self.assertEqual(kwargs_new["animals"][49], "ewöl")
 
-        with self.assertRaises(Warning):
-            self.neuro_batch.transform('str', [0])
+        with warnings.catch_warnings(record=True) as w:
+            self.neuro_batch.transform('str')
+            assert len(w) == 1
 
     def test_predict(self):
         y_predicted = self.neuro_batch.predict(self.data, **self.kwargs)
         # assure that predict is batch wisely called
         self.assertEqual(y_predicted[0], 1)
         self.assertEqual(y_predicted[-1], (self.data.shape[0]/self.batch_size))
-        with self.assertRaises(Warning):
+        with warnings.catch_warnings(record=True) as w:
             self.neuro_batch.predict('str')
+            assert len(w) == 1

--- a/test/base_tests/test_photon_elements.py
+++ b/test/base_tests/test_photon_elements.py
@@ -1,6 +1,7 @@
 import unittest
-
+import warnings
 import numpy as np
+
 from sklearn.datasets import load_breast_cancer
 from sklearn.decomposition import PCA
 from sklearn.svm import SVC
@@ -630,12 +631,14 @@ class BranchTests(unittest.TestCase):
         def callback_func(X, y, **kwargs):
             pass
 
-        with self.assertRaises(Warning):
+        with warnings.catch_warnings(record=True) as w:
             my_callback = CallbackElement('final_element_callback', delegate_function=callback_func)
             test_branch += my_callback
             no_callback_pipe = test_branch.prepare_photon_pipe(test_branch.elements)
+            self.assertTrue(no_callback_pipe.elements[-1][1] is my_callback)
             test_branch.sanity_check_pipeline(no_callback_pipe)
-            self.assertFalse(no_callback_pipe[-1] is not my_callback)
+            self.assertFalse(no_callback_pipe.elements)
+            assert len(w) == 1
 
     def test_prepare_pipeline(self):
         self.assertEqual(len(self.transformer_branch.elements), 2)
@@ -906,8 +909,9 @@ class PreprocessingTests(unittest.TestCase):
     def test_predict_warning(self):
         pe = Preprocessing()
         pe.add(PipelineElement('SVC'))
-        with self.assertRaises(Warning):
+        with warnings.catch_warnings(record=True) as w:
             pe.predict([0, 1, 2])
+            assert len(w) == 1
 
 
 class DataFilterTests(unittest.TestCase):
@@ -985,5 +989,6 @@ class CallbackElementTests(unittest.TestCase):
         for pipeline in pipelines:
             pipeline.fit(self.X, self.y).predict(self.X)
 
-        with self.assertRaises(Warning):
+        with warnings.catch_warnings(record=True) as w:
             self.callback_branch_pipeline_error.fit(self.X, self.y).predict(self.X)
+            assert len(w) == 2

--- a/test/optimization_tests/random_search/test_random_search.py
+++ b/test/optimization_tests/random_search/test_random_search.py
@@ -36,7 +36,7 @@ class RandomSearchOptimizerTest(GridSearchOptimizerTest):
 
     def test_constraint_obligation(self):
         with self.assertRaises(ValueError):
-            opt = RandomSearchOptimizer(n_configurations=-1, limit_in_minutes=-1)
+            RandomSearchOptimizer(n_configurations=-1, limit_in_minutes=-1)
 
     def test_time_limit(self):
         self.optimizer = RandomSearchOptimizer(limit_in_minutes=0.05)  # 3 seconds

--- a/test/optimization_tests/random_search/test_random_search.py
+++ b/test/optimization_tests/random_search/test_random_search.py
@@ -1,3 +1,5 @@
+import time
+
 from photonai.base import PipelineElement
 from photonai.optimization import RandomSearchOptimizer, IntegerRange
 from ..grid_search.test_grid_search import GridSearchOptimizerTest
@@ -31,6 +33,20 @@ class RandomSearchOptimizerTest(GridSearchOptimizerTest):
         for config in self.optimizer.ask:
             configs.append(config)
         self.assertEqual(len(configs), 500)
+
+    def test_constraint_obligation(self):
+        with self.assertRaises(ValueError):
+            opt = RandomSearchOptimizer(n_configurations=-1, limit_in_minutes=-1)
+
+    def test_time_limit(self):
+        self.optimizer = RandomSearchOptimizer(limit_in_minutes=0.05)  # 3 seconds
+        self.optimizer.prepare(pipeline_elements=self.pipeline_elements, maximize_metric=True)
+        configs = []
+        start = time.time()
+        for config in self.optimizer.ask:
+            configs.append(config)
+        stop = time.time()
+        self.assertAlmostEqual(stop-start, 3, 2)
 
     def test_run(self):
         pass

--- a/test/optimization_tests/sk_opt/test_sk_opt.py
+++ b/test/optimization_tests/sk_opt/test_sk_opt.py
@@ -1,6 +1,9 @@
 from photonai.base import PipelineElement
-from photonai.optimization import SkOptOptimizer, IntegerRange
+from photonai.optimization import SkOptOptimizer, IntegerRange, Categorical, FloatRange, BooleanSwitch
+from photonai.optimization.hyperparameters import NumberRange
 from ..grid_search.test_grid_search import GridSearchOptimizerTest
+
+import warnings
 
 
 class SkOptOptimizerTest(GridSearchOptimizerTest):
@@ -18,3 +21,45 @@ class SkOptOptimizerTest(GridSearchOptimizerTest):
     def test_ask_advanced(self):
         with self.assertRaises(ValueError):
             super(SkOptOptimizerTest, self).test_ask_advanced()
+
+    def test_empty_hspace(self):
+        with warnings.catch_warnings(record=True) as w:
+            self.optimizer.prepare([], True)
+            self.assertIsNone(self.optimizer.optimizer)
+            assert len(w) == 1
+
+    def test_eliminate_one_value_hyperparams(self):
+        pipeline_elements = [PipelineElement('PCA', hyperparameters={'n_components': Categorical([5])}),
+                             PipelineElement("SVC", hyperparameters={'kernel': ['rbf'],
+                                                                     'shrinking': BooleanSwitch(),
+                                                                     'C':FloatRange(0.5, 2, range_type='linspace'),
+                                                                     'tol': FloatRange(0.1, 1, range_type='logspace')})]
+        with warnings.catch_warnings(record=True) as w:
+            self.optimizer.prepare(pipeline_elements, True)
+            assert len(w) == 1
+        self.assertIn('SVC__C', self.optimizer.hyperparameter_list)
+        self.assertIn('SVC__shrinking', self.optimizer.hyperparameter_list)
+        self.assertNotIn('PCA__n_components', self.optimizer.hyperparameter_list)
+        self.assertNotIn('SVC__kernel', self.optimizer.hyperparameter_list)
+
+        self.optimizer.prepare([pipeline_elements[0]], True)
+        self.assertIsNone(self.optimizer.optimizer)
+
+        i = 0
+        for val in self.optimizer.ask:
+            self.assertFalse(val)
+            i += 1
+        self.assertEqual(i, 1)
+
+    def test_geomspace(self):
+        pipeline_elements = [PipelineElement("SVC", hyperparameters={'kernel': ['rbf', 'poly'],
+                                                                     'C': FloatRange(0.1, 0.5, range_type='geomspace'),
+                                                                     'tol': FloatRange(0.001, 0.01)})]
+        with self.assertRaises(ValueError):
+            self.optimizer.prepare(pipeline_elements, True)
+
+    def test_unsported_param(self):
+        pipeline_elements = [PipelineElement("SVC", hyperparameters={'kernel': Categorical(['rbf', 'poly', 'sigmoid']),
+                                                                     'C': NumberRange(1, 3, range_type='range')})]
+        with self.assertRaises(ValueError):
+            self.optimizer.prepare(pipeline_elements, True)

--- a/test/optimization_tests/smac/test_smac.py
+++ b/test/optimization_tests/smac/test_smac.py
@@ -11,6 +11,7 @@ from photonai.base.photon_pipeline import PhotonPipeline
 from sklearn.datasets import fetch_olivetti_faces
 from sklearn.model_selection import ShuffleSplit
 from photonai.optimization import FloatRange, Categorical, IntegerRange
+from photonai.optimization.hyperparameters import NumberRange
 from photonai.optimization.smac.smac import SMACOptimizer
 
 try:
@@ -65,7 +66,7 @@ else:
             # DESIGN YOUR PIPELINE
             self.pipe = Hyperpipe('basic_svm_pipe',
                                   optimizer='smac',
-                                  optimizer_params={'facade': SMAC4HPO,
+                                  optimizer_params={'facade': SMAC4BO,
                                                     'scenario_dict': scenario_dict,
                                                     'rng': 42,
                                                     'smac_helper': self.smac_helper},
@@ -112,7 +113,7 @@ else:
                                  })
 
             # Optimize, using a SMAC directly
-            smac = SMAC4HPO(scenario=scenario, rng=42,
+            smac = SMAC4BO(scenario=scenario, rng=42,
                            tae_runner=self.objective_function_simple)
             _ = smac.optimize()
 
@@ -220,7 +221,7 @@ else:
                                  })
 
             # Optimize, using a SMAC directly
-            smac = SMAC4HPO(scenario=scenario, rng=42,
+            smac = SMAC4BO(scenario=scenario, rng=42,
                            tae_runner=self.objective_function_switch)
             _ = smac.optimize()
 
@@ -287,3 +288,31 @@ else:
             facades = ["SMAC4BO", SMAC4BO, "SMAC4AC", SMAC4AC, "SMAC4HPO", SMAC4HPO, "BOHB4HPO", BOHB4HPO]
             for facade in facades:
                 SMACOptimizer(facade=facade, scenario_dict=scenario_dict)
+
+        def test_other(self):
+            with warnings.catch_warnings(record=True) as w:
+                opt = SMACOptimizer(facade="SMAC4BO", intensifier_kwargs={'min_chall': 2})
+                assert len(w) == 1
+                self.assertIsNotNone(opt.intensifier_kwargs)
+
+            pipeline_elements = [PipelineElement('SVC', hyperparameters={'kernel': Categorical(["rbf", 'poly',
+                                                                                               "sigmoid"]),
+                                                                        'C': [0.6]})]
+            of = lambda x: x**2
+            with warnings.catch_warnings(record=True) as w:
+                opt.prepare(pipeline_elements=pipeline_elements, maximize_metric=True, objective_function=of)
+                assert len(w) == 1
+
+            pipeline_elements = [PipelineElement("SVC", hyperparameters={'C': FloatRange(0.1, 0.5,
+                                                                                         range_type='logspace')})]
+            opt = SMACOptimizer(facade="SMAC4BO")
+            with self.assertRaises(NotImplementedError):
+                opt.prepare(pipeline_elements=pipeline_elements, maximize_metric=True, objective_function=of)
+
+            pipeline_elements = [PipelineElement("SVC", hyperparameters={'C': NumberRange(1, 3,
+                                                                                         range_type='range')})]
+            opt = SMACOptimizer(facade="SMAC4BO")
+            with self.assertRaises(ValueError):
+                opt.prepare(pipeline_elements=pipeline_elements, maximize_metric=True, objective_function=of)
+
+

--- a/test/optimization_tests/smac/test_smac.py
+++ b/test/optimization_tests/smac/test_smac.py
@@ -89,7 +89,8 @@ else:
             self.pipe.add(PipelineElement('StandardScaler'))
             self.pipe += PipelineElement('PCA', hyperparameters={'n_components': IntegerRange(5, 30)})
             self.pipe += PipelineElement('SVC', hyperparameters={'kernel': Categorical(["rbf", 'poly']),
-                                                                 'C': FloatRange(0.5, 200)}, gamma='auto')
+                                                                 'C': FloatRange(0.001, 2, range_type='logspace')},
+                                         gamma='auto')
             self.X, self.y = self.simple_classification()
             self.pipe.fit(self.X, self.y)
 
@@ -100,7 +101,7 @@ else:
             cs.add_hyperparameter(n_components)
             kernel = CategoricalHyperparameter("SVC__kernel", ["rbf", 'poly'])
             cs.add_hyperparameter(kernel)
-            c = UniformFloatHyperparameter("SVC__C", 0.5, 200)
+            c = UniformFloatHyperparameter("SVC__C", 0.001, 2, log=True)
             cs.add_hyperparameter(c)
 
             # Scenario object
@@ -304,7 +305,7 @@ else:
                 assert len(w) == 1
 
             pipeline_elements = [PipelineElement("SVC", hyperparameters={'C': FloatRange(0.1, 0.5,
-                                                                                         range_type='logspace')})]
+                                                                                         range_type='geomspace')})]
             opt = SMACOptimizer(facade="SMAC4BO")
             with self.assertRaises(NotImplementedError):
                 opt.prepare(pipeline_elements=pipeline_elements, maximize_metric=True, objective_function=of)

--- a/test/optimization_tests/test_config_grid.py
+++ b/test/optimization_tests/test_config_grid.py
@@ -22,7 +22,7 @@ class CreateGlobalConfigBaseElements(unittest.TestCase):
         self.rf = PipelineElement("RandomForestClassifier")  # no hyperparameter
         self.pipeline_elements = [self.scaler, self.pca, self.svc, self.rf]
 
-    def create_global_config_one_element_test(self):
+    def test_create_global_config_one_element(self):
         """
         Test for function create_global_config_dict with one element in param pipeline_elements (:list)
         """
@@ -44,7 +44,7 @@ class CreateGlobalConfigBaseElements(unittest.TestCase):
                                                                      {'PCA__n_components': 2}])
         self.assertListEqual(create_global_config_grid([self.rf]), [{}])   # no hyperparameter
 
-    def create_global_config_some_elements_test(self):
+    def test_create_global_config_some_elements(self):
         """
         Test for function create_global_config_dict with three elements in param pipeline_elements (:list)
 
@@ -97,7 +97,7 @@ class CreateGlobalConfigAdvancedElements(PhotonBaseTest):
         self.switch_in_switch = Switch('Switch_in_switch', [self.branch,
                                                             self.pipe_switch])
 
-    def create_global_config_switch_test(self):
+    def test_create_global_config_switch(self):
         """
         assert number of different configs to test
         each config combi for each element: 4 for SVC and 3 for logistic regression = 7
@@ -120,7 +120,7 @@ class CreateGlobalConfigAdvancedElements(PhotonBaseTest):
                                                                              {'switch__current_element': (1, 1)},
                                                                              {'switch__current_element': (1, 2)}])
 
-    def create_global_config_branch_test(self):
+    def test_create_global_config_branch(self):
         """
         Test for function create_global_config_dict/grid with branch element.
         """
@@ -135,7 +135,7 @@ class CreateGlobalConfigAdvancedElements(PhotonBaseTest):
                                                        {'branch__SVC__C': 1, 'branch__SVC__kernel': 'rbf'},
                                                        {'branch__SVC__C': 1, 'branch__SVC__kernel': 'sigmoid'}])
 
-    def create_global_config_switch_in_swicht_test(self):
+    def test_create_global_config_switch_in_swicht(self):
         """
         Test for function create_global_config_dict/grid with switch in switch.
 
@@ -173,5 +173,6 @@ class CreateGlobalConfigAdvancedElements(PhotonBaseTest):
         hp += stack
         hp += PipelineElement("SVC", hyperparameters={'kernel': ["linear", "rbf", "sigmoid"]})
         X, y = load_breast_cancer(return_X_y=True)
-        with self.assertRaises(Warning):
+
+        with self.assertRaises(ValueError):
             hp.fit(X, y)

--- a/test/optimization_tests/test_hyperparameters.py
+++ b/test/optimization_tests/test_hyperparameters.py
@@ -1,7 +1,9 @@
 import unittest
 import numpy as np
+import warnings
 
 from photonai.optimization import FloatRange, IntegerRange, Categorical, BooleanSwitch
+from photonai.optimization.hyperparameters import NumberRange
 
 
 class HyperparameterBaseTest(unittest.TestCase):
@@ -100,9 +102,14 @@ class NumberRangeTest(unittest.TestCase):
             number_range = IntegerRange(start=0, stop=self.end, range_type="geomspace")
             number_range.transform()
 
+        number_range = FloatRange(start=0.1, stop=self.end, range_type="geomspace")
+        number_range.transform()
+
         with self.assertRaises(ValueError):
             number_range = IntegerRange(start=1, stop=15, range_type="logspace")
             number_range.transform()
+        number_range = FloatRange(start=0.1, stop=self.end, range_type="logspace")
+        number_range.transform()
 
         with self.assertRaises(ValueError):
             IntegerRange(start=self.start, stop=self.end, range_type="ownspace")
@@ -120,6 +127,8 @@ class HyperparameterOtherTest(unittest.TestCase):
         """
         items = "Lorem ipsum dolor sit amet consetetur sadipscing elitr".split(" ")
         categorical = Categorical(values=items)
+        self.assertEqual(categorical[2], "dolor")
+        self.assertListEqual(categorical[2:5], items[2:5])
         self.assertListEqual(categorical.values, items)
 
     def test_boolean_switch(self):
@@ -128,3 +137,18 @@ class HyperparameterOtherTest(unittest.TestCase):
         """
         boolean_switch = BooleanSwitch()
         self.assertListEqual(boolean_switch.values, [True, False])
+
+    def test_start_stop_problem(self):
+        with warnings.catch_warnings(record=True) as w:
+            integer_range = IntegerRange(2, 1)
+            integer_range.transform()
+            assert len(w) == 1
+
+    def test_dtypes(self):
+        with warnings.catch_warnings(record=True) as w:
+            complex_range = NumberRange(1, 5, num_type=complex, range_type="range")
+            complex_range.transform()
+            str_range = NumberRange(1, 2, num_type=np.bool_, range_type="range")
+            str_range.transform()
+            assert len(w) == 0
+

--- a/test/optimization_tests/test_performance_constraints.py
+++ b/test/optimization_tests/test_performance_constraints.py
@@ -1,5 +1,6 @@
 import unittest
 import numpy as np
+import warnings
 
 from photonai.optimization import DummyPerformance, MinimumPerformance, BestPerformance, IntegerRange
 from photonai.optimization.performance_constraints import PhotonBaseConstraint
@@ -66,6 +67,8 @@ class PhotonBaseConstraintTest(unittest.TestCase):
         with self.assertRaises(KeyError):
             PhotonBaseConstraint(strategy='last', metric='f1_score')
 
+
+
     def test_greater_is_better(self):
         """
         Test for set different metrics (score/error).
@@ -82,8 +85,10 @@ class PhotonBaseConstraintTest(unittest.TestCase):
         Test for shall_continue function.
         """
         # reutrns every times False if the metric does not exists
-        self.constraint_object.metric = "own_metric"
-        self.assertEqual(self.constraint_object.shall_continue(self.dummy_config_item), True)
+        with warnings.catch_warnings(record=True) as w:
+            self.constraint_object.metric = "own_metric"
+            self.assertEqual(self.constraint_object.shall_continue(self.dummy_config_item), True)
+            assert len(w) == 1
 
         # dummy_item with random values
         # score
@@ -163,7 +168,7 @@ class BestPerformanceTest(PhotonBaseConstraintTest):
         # DESIGN YOUR PIPELINE
         my_pipe = Hyperpipe(name='performance_pipe',
                             optimizer='random_search',
-                            optimizer_params={'limit_in_minutes':2},
+                            optimizer_params={'limit_in_minutes':1},
                             metrics=['mean_squared_error'],
                             best_config_metric='mean_squared_error',
                             inner_cv=KFold(n_splits=inner_fold_length),
@@ -182,7 +187,7 @@ class BestPerformanceTest(PhotonBaseConstraintTest):
 
         configs = []
 
-        for i in range(len(configs)-1):
+        for i in range(len(results)-1):
             configs.append([x.validation.metrics['mean_squared_error'] for x in results[i].inner_folds])
 
         threshold = np.inf

--- a/test/processing_tests/test_metrics.py
+++ b/test/processing_tests/test_metrics.py
@@ -1,7 +1,7 @@
 import unittest
 import types
 import numpy as np
-import math
+import warnings
 
 from photonai.processing.metrics import Scorer, spearman_correlation, specificity, sensitivity, one_hot_to_binary, \
     pearson_correlation, balanced_accuracy, categorical_accuracy_score, variance_explained_score
@@ -25,7 +25,8 @@ class ScorerTest(unittest.TestCase):
             self.assertIsInstance(Scorer.create(implemented_metric), types.FunctionType)
 
         for not_implemented_metric in self.some_not_implemented_metrics:
-            self.assertIsNone(Scorer.create(not_implemented_metric))
+            with self.assertRaises(NameError):
+                self.assertIsNone(Scorer.create(not_implemented_metric))
 
     def test_greater_is_better_distinction(self):
         """
@@ -50,8 +51,8 @@ class ScorerTest(unittest.TestCase):
                                                            [implemented_metric])[implemented_metric], float)
 
         for not_implemented_metric in self.some_not_implemented_metrics:
-            np.testing.assert_equal(Scorer.calculate_metrics([1, 1, 0, 1],
-                                                             [0, 1, 0, 1],
+            with self.assertRaises(NameError):
+                np.testing.assert_equal(Scorer.calculate_metrics([1, 1, 0, 1], [0, 1, 0, 1],
                                                              [not_implemented_metric])[not_implemented_metric], np.nan)
 
     def test_doubled_custom_metric(self):
@@ -60,9 +61,6 @@ class ScorerTest(unittest.TestCase):
             return 99.9
 
         Scorer.register_custom_metric(('a_custom_metric', custom_metric))
-
-        with self.assertRaises(Warning):
-            Scorer.register_custom_metric(('a_custom_metric', custom_metric))
 
         with self.assertRaises(ValueError):
             Scorer.register_custom_metric(None)

--- a/test/processing_tests/test_results_handler.py
+++ b/test/processing_tests/test_results_handler.py
@@ -2,7 +2,7 @@ import os
 import shutil
 from io import StringIO
 import uuid
-import time
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -271,9 +271,10 @@ class ResultsHandlerTest(PhotonBaseTest):
 
         # write again to mongodb
         hyperpipe.fit(self.__X, self.__y)
-        with self.assertRaises(Warning):
+        with warnings.catch_warnings(record=True) as w:
             my_mongo_result_handler.load_from_mongodb(pipe_name=hyperpipe.name,
                                                       mongodb_connect_url=self.mongodb_path)
+            assert len(w) == 1
 
         with self.assertRaises(FileNotFoundError):
             my_result_handler.load_from_mongodb(pipe_name='any_weird_name_1238934384834234892384382',


### PR DESCRIPTION
- [x] new handling of warnings (use warnings.warn instead of raise warning). unittest with warnings.catch_warning(record=True)
- [x] change some warnings to error and the other way round
- [x] use smac newest/unspecific version (0.12.3)
- [x] enable BooleanSwitch to Bayesian Optimization (scikit-optimize and smac)
- [x] add some test for optimization

scikit-optimize 0.7.4 is not compatible with scikit-learn 0.23.2 as mentioned [here](https://github.com/scikit-optimize/scikit-optimize/issues/931). Even if the version default of scikit-learn (0.23.1) is not nice, a few examples/user guides are based on sk_opt and will therefore throw errors. Alternatively we could give warnings when using sk_opt. Maybe you have a better idea, but I find it difficult to ignore completely.
