### PR TITLE
Test-Adaptations for Dask 2020.12.0-2021.2.0

### DIFF
--- a/examples/optimizer/skopt_example.py
+++ b/examples/optimizer/skopt_example.py
@@ -1,30 +1,36 @@
-from sklearn.datasets import load_boston
-from sklearn.model_selection import KFold, ShuffleSplit
+from sklearn.datasets import load_diabetes
+from sklearn.model_selection import ShuffleSplit
 
 from photonai.base import Hyperpipe, PipelineElement
 from photonai.optimization import FloatRange, Categorical
 
-# WE USE THE BOSTON HOUSING DATA FROM SKLEARN
-X, y = load_boston(return_X_y=True)
+# WE USE THE DIABETES DATA FROM SKLEARN
+X, y = load_diabetes(return_X_y=True)
 
 # DESIGN YOUR PIPELINE
 my_pipe = Hyperpipe('skopt_example',
                     optimizer='sk_opt',  # which optimizer PHOTONAI shall use, in this case sk_opt
-                    optimizer_params={'n_configurations': 25, 'acq_func': 'LCB', 'acq_func_kwargs': {'kappa': 1.96}},
-                    metrics=['mean_squared_error', 'pearson_correlation'],
-                    best_config_metric='mean_squared_error',
-                    outer_cv=ShuffleSplit(n_splits=4, test_size=0.2),
-                    inner_cv=KFold(n_splits=3),
+                    optimizer_params={'n_configurations': 25,
+                                      'n_initial_points': 10,
+                                      'base_estimator': 'GP',
+                                      'initial_point_generator': 'grid',
+                                      'acq_func': 'LCB',
+                                      'acq_func_kwargs': {'kappa': 1.96}
+                                      },
+                    metrics=['mean_squared_error', 'mean_absolute_error'],
+                    best_config_metric='mean_absolute_error',
+                    outer_cv=ShuffleSplit(n_splits=3, test_size=0.2),
+                    inner_cv=ShuffleSplit(n_splits=3, test_size=0.3),
                     verbosity=0,
                     project_folder='./tmp/')
 
 # ADD ELEMENTS TO YOUR PIPELINE
-# first normalize all features
+# first scale all features
 my_pipe += PipelineElement('StandardScaler')
 
 # engage and optimize SVR
-# linspace and logspace is converted to uniform and log-uniform priors in skopt
-my_pipe += PipelineElement('SVR', hyperparameters={'C': FloatRange(1e-3, 100, range_type='logspace'),
+# linspace and logspace are converted to uniform and log-uniform priors in skopt
+my_pipe += PipelineElement('SVR', hyperparameters={'C': FloatRange(0.1, 100, range_type='linspace'),
                                                    'epsilon': FloatRange(1e-3, 10, range_type='logspace'),
                                                    'tol': FloatRange(1e-4, 1e-2, range_type='linspace'),
                                                    'kernel': Categorical(['linear', 'rbf', 'poly'])})

--- a/photonai/optimization/grid_search/grid_search.py
+++ b/photonai/optimization/grid_search/grid_search.py
@@ -33,7 +33,7 @@ class GridSearchOptimizer(PhotonSlaveOptimizer):
 
     def prepare(self, pipeline_elements: list, maximize_metric: bool) -> None:
         """
-        Creates a grid from a list of PipelineElements.
+        Create a grid from a list of PipelineElements.
         Hyperparameters can be accessed via pipe_element.hyperparameters.
 
         Parameters:
@@ -54,7 +54,7 @@ class GridSearchOptimizer(PhotonSlaveOptimizer):
         Generator for new configs - ask method.
 
         Returns:
-            Yields the next config.
+            Yield the next config.
 
         """
         for parameters in self.param_grid:
@@ -64,8 +64,8 @@ class GridSearchOptimizer(PhotonSlaveOptimizer):
 class RandomGridSearchOptimizer(GridSearchOptimizer):
     """Random grid search optimizer.
 
-    Searches for the best configuration by randomly
-    testing n points of a grid of possible hyperparameters.
+    Search for the best configuration by randomly
+    testing n points in a grid of possible hyperparameters.
 
     Example:
         ``` python
@@ -85,10 +85,10 @@ class RandomGridSearchOptimizer(GridSearchOptimizer):
 
         Parameters:
             limit_in_minutes:
-                Total time in minutes.
+                Total time limit in minutes.
 
             n_configurations:
-                Number of configurations to be calculated.
+                Maximum number of configurations to be calculated.
 
         """
         super(RandomGridSearchOptimizer, self).__init__()
@@ -126,7 +126,7 @@ class RandomGridSearchOptimizer(GridSearchOptimizer):
         Generator for new configs - ask method.
 
         Returns:
-            Yields the next config.
+            Yield the next config.
 
         """
         if self.start_time is None and self.limit_in_minutes is not None:

--- a/photonai/optimization/random_search/random_search.py
+++ b/photonai/optimization/random_search/random_search.py
@@ -20,10 +20,10 @@ class RandomSearchOptimizer(PhotonSlaveOptimizer):
 
         Parameters:
             limit_in_minutes:
-                Total time in minutes.
+                Total time limit in minutes.
 
             n_configurations:
-                Number of configurations to be calculated.
+                Maximum number of configurations to be calculated.
 
         """
         self.pipeline_elements = None
@@ -51,7 +51,7 @@ class RandomSearchOptimizer(PhotonSlaveOptimizer):
 
     def prepare(self, pipeline_elements: list, maximize_metric: bool) -> None:
         """
-        Initializes grid free random hyperparameter search.
+        Initialize the grid-free random hyperparameter search.
 
         Parameters:
             pipeline_elements:
@@ -70,7 +70,7 @@ class RandomSearchOptimizer(PhotonSlaveOptimizer):
         Generator for new configs - ask method.
 
         Returns:
-            Yields the next config.
+            Yield the next config.
 
         """
         while True:

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,8 @@ setup(
         'prettytable',
         'seaborn',
         'joblib',
-        'dask==2.30.0',
-        'distributed==2.30.1',
+        'dask==2021.2.0',
+        'distributed==2021.2.0',
         'scikit-optimize',
         'xlrd']
 )

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,8 @@ setup(
         'prettytable',
         'seaborn',
         'joblib',
-        'dask==2021.2.0',
-        'distributed==2021.2.0',
+        'dask',
+        'distributed',
         'scikit-optimize',
         'xlrd']
 )

--- a/test/optimization_tests/grid_search_tests/test_grid_search.py
+++ b/test/optimization_tests/grid_search_tests/test_grid_search.py
@@ -116,5 +116,5 @@ class BaseOptimizerTests(unittest.TestCase):
     @staticmethod
     def test_master_interface():
         opt = PhotonMasterOptimizer()
-        opt.prepare(list(), True, None)
+        opt.prepare(list(), True, lambda x: x)
         opt.optimize()

--- a/test/optimization_tests/nevergrad_tests/test_nevergrad.py
+++ b/test/optimization_tests/nevergrad_tests/test_nevergrad.py
@@ -113,7 +113,7 @@ class NevergradIntegrationTest(unittest.TestCase):
                                                                      'C': [0.6], 'coef0': Categorical([0.5])})]
 
         def of(x):
-            x ** 2
+            return x ** 2
 
         with warnings.catch_warnings(record=True) as w:
             opt.prepare(pipeline_elements=pipeline_elements, maximize_metric=True, objective_function=of)

--- a/test/optimization_tests/nevergrad_tests/test_nevergrad.py
+++ b/test/optimization_tests/nevergrad_tests/test_nevergrad.py
@@ -111,7 +111,10 @@ class NevergradIntegrationTest(unittest.TestCase):
         opt = NevergradOptimizer(facade="NGO", n_configurations=10)
         pipeline_elements = [PipelineElement('SVC', hyperparameters={'kernel': ["sigmoid", "rbf"],
                                                                      'C': [0.6], 'coef0': Categorical([0.5])})]
-        of = lambda x: x ** 2
+
+        def of(x):
+            x ** 2
+
         with warnings.catch_warnings(record=True) as w:
             opt.prepare(pipeline_elements=pipeline_elements, maximize_metric=True, objective_function=of)
             assert any("PHOTONAI has detected some" in s for s in [e.message.args[0] for e in w])

--- a/test/optimization_tests/nevergrad_tests/test_nevergrad_not_installed.py
+++ b/test/optimization_tests/nevergrad_tests/test_nevergrad_not_installed.py
@@ -11,9 +11,7 @@ class NevergradOptimizerWithoutRequirementsTest(unittest.TestCase):
         photonai_ng.__found__ = False
 
     def test_imports(self):
-        """
-        Test for ModuleNotFoundError (requirements.txt).
-        """
+        """Test for ModuleNotFoundError (requirements.txt)."""
         with self.assertRaises(ModuleNotFoundError):
             NevergradOptimizer()
 

--- a/test/optimization_tests/smac_tests/test_smac.py
+++ b/test/optimization_tests/smac_tests/test_smac.py
@@ -135,7 +135,7 @@ class Smac3IntegrationTest(unittest.TestCase):
         pipe.add(PipelineElement('StandardScaler'))
         pipe += PipelineElement('PCA', hyperparameters={'n_components': IntegerRange(5, 30)})
         pipe += PipelineElement('SVC', hyperparameters={'kernel': Categorical(["rbf", 'poly']),
-                                                             'C': FloatRange(0.5, 200)}, gamma='auto')
+                                                        'C': FloatRange(0.5, 200)}, gamma='auto')
         X, y = self.simple_classification()
         pipe.fit(X, y)
         self.assertEqual(len(pipe.results.outer_folds[0].tested_config_list), n_configurations)

--- a/test/processing_tests/test_permutation_test.py
+++ b/test/processing_tests/test_permutation_test.py
@@ -1,4 +1,5 @@
 import uuid
+import os
 import numpy as np
 from bson.objectid import ObjectId
 from sklearn.datasets import load_breast_cancer
@@ -8,6 +9,36 @@ from photonai.base import Hyperpipe, OutputSettings, PipelineElement
 from photonai.processing.permutation_test import PermutationTest
 from photonai.processing.results_handler import ResultsHandler
 from photonai.helper.photon_base_test import PhotonBaseTest
+
+
+def create_hyperpipe():
+    # this is needed here for the parallelization
+    from photonai.base import Hyperpipe, PipelineElement, OutputSettings
+    from photonai.optimization import IntegerRange
+    from sklearn.model_selection import GroupKFold, KFold
+
+    base_folder = os.path.dirname(os.path.abspath(__file__))
+    settings = OutputSettings(mongodb_connect_url='mongodb://localhost:27017/photon_results', save_output=False)
+    my_pipe = Hyperpipe('permutation_test_1',
+                        optimizer='grid_search',
+                        metrics=['accuracy', 'precision', 'recall'],
+                        best_config_metric='accuracy',
+                        outer_cv=GroupKFold(n_splits=2),
+                        inner_cv=KFold(n_splits=2),
+                        calculate_metrics_across_folds=True,
+                        use_test_set=True,
+                        project_folder=os.path.join(base_folder, "tmp"),
+                        verbosity=0,
+                        output_settings=settings)
+
+    my_pipe += PipelineElement("StandardScaler", hyperparameters={},
+                               test_disabled=False, with_mean=True, with_std=True)
+    my_pipe += PipelineElement("PCA", hyperparameters={'n_components': IntegerRange(3, 5)},
+                               test_disabled=False)
+    my_pipe += PipelineElement("SVC", hyperparameters={'kernel': ['linear', 'rbf']},  # C': FloatRange(0.1, 5),
+                               gamma='scale', max_iter=1000000)
+
+    return my_pipe
 
 
 class PermutationTestTests(PhotonBaseTest):
@@ -61,39 +92,6 @@ class PermutationTestTests(PhotonBaseTest):
                                                      ObjectId(wizard_obj_id), True)
         self.assertEqual(latest_item.name, wizard_obj_id)
 
-    def create_hyperpipe(self):
-        # this is needed here for the parallelisation
-        from photonai.base import Hyperpipe, PipelineElement, OutputSettings
-        from photonai.optimization import IntegerRange
-        from sklearn.model_selection import GroupKFold
-        from sklearn.model_selection import KFold
-
-        settings = OutputSettings(mongodb_connect_url='mongodb://localhost:27017/photon_results')
-        my_pipe = Hyperpipe('permutation_test_1',
-                            optimizer='grid_search',
-                            metrics=['accuracy', 'precision', 'recall'],
-                            best_config_metric='accuracy',
-                            outer_cv=GroupKFold(n_splits=2),
-                            inner_cv=KFold(n_splits=2),
-                            calculate_metrics_across_folds=True,
-                            use_test_set=True,
-                            verbosity=0,
-                            project_folder=self.tmp_folder_path,
-                            output_settings=settings)
-
-        # Add transformer elements
-        my_pipe += PipelineElement("StandardScaler", hyperparameters={},
-                                   test_disabled=False, with_mean=True, with_std=True)
-
-        my_pipe += PipelineElement("PCA", hyperparameters={'n_components': IntegerRange(3, 5)},
-                                   test_disabled=False)
-
-        # Add estimator
-        my_pipe += PipelineElement("SVC", hyperparameters={'kernel': ['linear', 'rbf']},  # C': FloatRange(0.1, 5),
-                                   gamma='scale', max_iter=1000000)
-
-        return my_pipe
-
     def create_hyperpipe_no_mongo(self):
         from photonai.base import Hyperpipe
         from sklearn.model_selection import KFold
@@ -120,7 +118,7 @@ class PermutationTestTests(PhotonBaseTest):
         X, y = load_breast_cancer(return_X_y=True)
         my_perm_id = str(uuid.uuid4())
         groups = np.random.random_integers(0, 3, (len(y),))
-        perm_tester = PermutationTest(self.create_hyperpipe, n_perms=2, n_processes=3, random_state=11,
+        perm_tester = PermutationTest(create_hyperpipe, n_perms=2, n_processes=3, random_state=11,
                                       permutation_id=my_perm_id)
         perm_tester.fit(X, y, groups=groups)
 
@@ -129,7 +127,7 @@ class PermutationTestTests(PhotonBaseTest):
         X, y = np.random.random((200, 5)), np.random.randint(0, 2, size=(200, ))
         my_perm_id = str(uuid.uuid4())
         groups = np.random.random_integers(0, 3, (len(y),))
-        perm_tester = PermutationTest(self.create_hyperpipe, n_perms=2, n_processes=3, random_state=11,
+        perm_tester = PermutationTest(create_hyperpipe, n_perms=2, n_processes=3, random_state=11,
                                       permutation_id=my_perm_id)
         with self.assertRaises(RuntimeError):
             perm_tester.fit(X, y, groups=groups)
@@ -138,7 +136,7 @@ class PermutationTestTests(PhotonBaseTest):
         X, y = load_breast_cancer(return_X_y=True)
         my_perm_id = str(uuid.uuid4())
         groups = np.random.random_integers(0, 3, (len(y),))
-        perm_tester = PermutationTest(self.create_hyperpipe, n_perms=2, n_processes=1, random_state=11,
+        perm_tester = PermutationTest(create_hyperpipe, n_perms=2, n_processes=1, random_state=11,
                                       permutation_id=my_perm_id)
         perm_tester.fit(X, y, groups=groups)
 


### PR DESCRIPTION
Move function `self.create_hyperpipe()` to `create_hyperpipe()` to enable a pickle-based serialization for newer versions of dask/distributed.

Works only for versions != 2021.3.x -> is probably related to dask/distributed#4645 and solved with 2021.04.0.

Small skopt adaptations: use defaults (base_estimator: ET->GP)