### PR TITLE
Feature/score train v2

### DIFF
--- a/photonai/base/hyperpipe.py
+++ b/photonai/base/hyperpipe.py
@@ -298,6 +298,7 @@ class Hyperpipe(BaseEstimator):
                  nr_of_processes: int = 1,
                  multi_threading: bool = True,
                  allow_multidim_targets: bool = False,
+                 raise_error: bool = False,
                  score_train: bool = True):
         """
         Initialize the object.
@@ -424,6 +425,9 @@ class Hyperpipe(BaseEstimator):
             score_train:
                 metrics for the train-set are only calculated if score_train is true.
 
+            raise_error:
+                if true, errors in the inner fold are raised instead of suppressed as warnings.
+
         """
 
         self.name = re.sub(r'\W+', '', name)
@@ -519,6 +523,7 @@ class Hyperpipe(BaseEstimator):
         self.allow_multidim_targets = allow_multidim_targets
         self.is_final_fit = False
         self.score_train = score_train
+        self.raise_error = raise_error
 
         # ====================== Random Seed ===========================
         self.random_state = random_seed
@@ -1091,7 +1096,8 @@ class Hyperpipe(BaseEstimator):
                                                            cache_updater=self.recursive_cache_folder_propagation,
                                                            dummy_estimator=dummy_estimator,
                                                            result_obj=outer_fold,
-                                                           score_train=self.score_train)
+                                                           score_train=self.score_train,
+                                                           raise_error=self.raise_error)
                     # 2. monitor outputs
                     self.results.outer_folds.append(outer_fold)
 

--- a/photonai/base/hyperpipe.py
+++ b/photonai/base/hyperpipe.py
@@ -297,7 +297,8 @@ class Hyperpipe(BaseEstimator):
                  cache_folder: str = None,
                  nr_of_processes: int = 1,
                  multi_threading: bool = True,
-                 allow_multidim_targets: bool = False):
+                 allow_multidim_targets: bool = False,
+                 score_train: bool = True):
         """
         Initialize the object.
 
@@ -420,6 +421,9 @@ class Hyperpipe(BaseEstimator):
             allow_multidim_targets:
                 Allows multidimensional targets.
 
+            score_train:
+                metrics for the train-set are only calculated if score_train is true.
+
         """
 
         self.name = re.sub(r'\W+', '', name)
@@ -514,6 +518,7 @@ class Hyperpipe(BaseEstimator):
         self.permutation_id = permutation_id
         self.allow_multidim_targets = allow_multidim_targets
         self.is_final_fit = False
+        self.score_train = score_train
 
         # ====================== Random Seed ===========================
         self.random_state = random_seed
@@ -1087,7 +1092,8 @@ class Hyperpipe(BaseEstimator):
                                                            cache_folder=self.cache_folder,
                                                            cache_updater=self.recursive_cache_folder_propagation,
                                                            dummy_estimator=dummy_estimator,
-                                                           result_obj=outer_fold)
+                                                           result_obj=outer_fold,
+                                                           score_train=self.score_train)
                     # 2. monitor outputs
                     self.results.outer_folds.append(outer_fold)
 

--- a/photonai/base/hyperpipe.py
+++ b/photonai/base/hyperpipe.py
@@ -946,8 +946,6 @@ class Hyperpipe(BaseEstimator):
                 else:
                     self.results.best_config_feature_importances = feature_importances
 
-                    self.results.best_config_feature_importances = feature_importances
-
                     # write backmapping file only if optimum_pipes inverse_transform works completely.
                     # restriction: only a faulty inverse_transform is considered, missing ones are further ignored.
                     # with warnings.catch_warnings(record=True) as w:

--- a/photonai/processing/inner_folds.py
+++ b/photonai/processing/inner_folds.py
@@ -359,20 +359,21 @@ class InnerFoldManager(object):
 
         logger.debug('Scoring Training Data')
         # score train data
-        scores = {}
-        for metric in list(curr_test_fold.metrics.keys()):
-            scores[metric] = 0
-        curr_train_fold = MDBScoreInformation(metrics=scores,
-                                              score_duration=0,
-                                              y_pred=list(np.zeros_like(job.train_data.y)),
-                                              y_true=list(job.train_data.y),
-                                              indices=np.asarray(job.train_data.indices).tolist(),
-                                              probabilities=[])
         if job.score_train:
             curr_train_fold = InnerFoldManager.score(pipe, job.train_data.X, job.train_data.y, job.metrics,
                                                  indices=job.train_data.indices,
                                                  training=True,
                                                  scorer=job.scorer, **job.train_data.cv_kwargs)
+        else:
+            scores = {}
+            for metric in list(curr_test_fold.metrics.keys()):
+                scores[metric] = 0
+            curr_train_fold = MDBScoreInformation(metrics=scores,
+                                                  score_duration=0,
+                                                  y_pred=list(np.zeros_like(job.train_data.y)),
+                                                  y_true=list(job.train_data.y),
+                                                  indices=np.asarray(job.train_data.indices).tolist(),
+                                                  probabilities=[])
 
         return curr_test_fold, curr_train_fold
 

--- a/photonai/processing/inner_folds.py
+++ b/photonai/processing/inner_folds.py
@@ -370,7 +370,7 @@ class InnerFoldManager(object):
     @staticmethod
     def score(estimator, X, y_true, metrics, indices=[],
               calculate_metrics: bool = True, training: bool = False,
-              scorer: Scorer = None, score_train=True, **kwargs):
+              dummy: bool = False, scorer: Scorer = None, score_train=True, **kwargs):
         """Uses the pipeline to predict the given data,
         compare it to the truth values and calculate metrics
 
@@ -427,7 +427,7 @@ class InnerFoldManager(object):
                                         indices=np.asarray(indices).tolist(),
                                         probabilities=[])
 
-        if not training:
+        if not training or (training and dummy):
             y_pred = estimator.predict(X, **kwargs)
         else:
             X, y_true_new, kwargs_new = estimator.transform(X, y_true, **kwargs)

--- a/photonai/processing/inner_folds.py
+++ b/photonai/processing/inner_folds.py
@@ -66,7 +66,8 @@ class InnerFoldManager(object):
                  training: bool = False,
                  cache_folder=None,
                  cache_updater=None,
-                 scorer: Scorer = None):
+                 scorer: Scorer = None,
+                 score_train: bool = True):
 
         self.params = specific_config
         self.pipe = pipe_ctor
@@ -81,6 +82,7 @@ class InnerFoldManager(object):
 
         self.raise_error = raise_error
         self.training = training
+        self.score_train = score_train
 
     def fit(self, X, y, **kwargs):
         """Iterates over cross-validation folds and trains the pipeline,
@@ -136,7 +138,8 @@ class InnerFoldManager(object):
                                                                                            kwargs_cv_train),
                                                        test_data=InnerFoldManager.JobData(test_X, test_y, test,
                                                                                           kwargs_cv_test),
-                                                       scorer=self.scorer)
+                                                       scorer=self.scorer,
+                                                       score_train=self.score_train)
 
                 # only for unparallel processing
                 # inform children in which inner fold we are
@@ -224,7 +227,8 @@ class InnerFoldManager(object):
                                        callbacks=self.optimization_constraints,
                                        train_data=self.JobData(train_cut_X, train_cut_y, train_cut, train_cut_kwargs),
                                        test_data=self.JobData(test_X, test_y, test, kwargs_cv_test),
-                                       scorer=self.scorer)
+                                       scorer=self.scorer,
+                                       score_train=self.score_train)
             curr_test_cut, curr_train_cut = InnerFoldManager.fit_and_score(job_data)
             learning_curves.append([self.cross_validation_infos.learning_curves_cut.values[i], curr_test_cut.metrics,
                                     curr_train_cut.metrics])
@@ -239,7 +243,7 @@ class InnerFoldManager(object):
 
     class InnerCVJob:
 
-        def __init__(self, pipe, config, metrics, callbacks, train_data, test_data, scorer):
+        def __init__(self, pipe, config, metrics, callbacks, train_data, test_data, scorer, score_train):
             self.pipe = pipe
             self.config = config
             self.metrics = metrics
@@ -247,6 +251,7 @@ class InnerFoldManager(object):
             self.train_data = train_data
             self.test_data = test_data
             self.scorer = scorer
+            self.score_train = score_train
 
     @staticmethod
     def update_config_item_with_inner_fold(config_item, fold_cnt, curr_train_fold, curr_test_fold, time_monitor,
@@ -344,7 +349,7 @@ class InnerFoldManager(object):
         # start fitting
         pipe.fit(job.train_data.X, job.train_data.y, **job.train_data.cv_kwargs)
 
-        logger.debug('Scoring Training Data')
+        logger.debug('Scoring Test Data')
 
         # score test data
         curr_test_fold = InnerFoldManager.score(pipe, job.test_data.X, job.test_data.y, job.metrics,
@@ -352,9 +357,19 @@ class InnerFoldManager(object):
                                                 scorer=job.scorer,
                                                 **job.test_data.cv_kwargs)
 
-        logger.debug('Scoring Test Data')
+        logger.debug('Scoring Training Data')
         # score train data
-        curr_train_fold = InnerFoldManager.score(pipe, job.train_data.X, job.train_data.y, job.metrics,
+        scores = {}
+        for metric in list(curr_test_fold.metrics.keys()):
+            scores[metric] = 0
+        curr_train_fold = MDBScoreInformation(metrics=scores,
+                                              score_duration=0,
+                                              y_pred=list(np.zeros_like(job.train_data.y)),
+                                              y_true=list(job.train_data.y),
+                                              indices=np.asarray(job.train_data.indices).tolist(),
+                                              probabilities=[])
+        if job.score_train:
+            curr_train_fold = InnerFoldManager.score(pipe, job.train_data.X, job.train_data.y, job.metrics,
                                                  indices=job.train_data.indices,
                                                  training=True,
                                                  scorer=job.scorer, **job.train_data.cv_kwargs)

--- a/photonai/processing/metrics.py
+++ b/photonai/processing/metrics.py
@@ -29,9 +29,9 @@ class Scorer:
         'precision': ('sklearn.metrics', 'precision_score', 'score'),
         'recall': ('sklearn.metrics', 'recall_score', 'score'),
         'auc': ('sklearn.metrics', 'roc_auc_score', 'score'),
-        'sensitivity': ('photonai.processing.metrics', 'sensitivity', 'score'),
+        'sensitivity': ('sklearn.metrics', 'recall_score', 'score'),
         'specificity': ('photonai.processing.metrics', 'specificity', 'score'),
-        'balanced_accuracy': ('photonai.processing.metrics', 'balanced_accuracy', 'score'),
+        'balanced_accuracy': ('sklearn.metrics', 'balanced_accuracy_score', 'score'),
         'categorical_accuracy': ('photonai.processing.metrics', 'categorical_accuracy_score', 'score'),
 
         # Regression

--- a/photonai/processing/outer_folds.py
+++ b/photonai/processing/outer_folds.py
@@ -390,7 +390,7 @@ class OuterFoldManager:
                 self.dummy_estimator.fit(dummy_y, self._validation_y)
                 train_scores = InnerFoldManager.score(self.dummy_estimator, self._validation_X, self._validation_y,
                                                       metrics=self.optimization_info.metrics,
-                                                      scorer=self.scorer, score_train=self.score_train)
+                                                      scorer=self.scorer)
 
                 # fill result tree with fold information
                 inner_fold = MDBInnerFold()
@@ -400,7 +400,7 @@ class OuterFoldManager:
                     test_scores = InnerFoldManager.score(self.dummy_estimator,
                                                          self._test_X, self._test_y,
                                                          metrics=self.optimization_info.metrics,
-                                                         scorer=self.scorer, score_train=self.score_train)
+                                                         scorer=self.scorer)
                     print_metrics("DUMMY", test_scores.metrics)
                     inner_fold.validation = test_scores
 

--- a/photonai/processing/outer_folds.py
+++ b/photonai/processing/outer_folds.py
@@ -392,6 +392,7 @@ class OuterFoldManager:
                 self.dummy_estimator.fit(dummy_y, self._validation_y)
                 train_scores = InnerFoldManager.score(self.dummy_estimator, self._validation_X, self._validation_y,
                                                       training=True,
+                                                      dummy=True,
                                                       metrics=self.optimization_info.metrics,
                                                       score_train=self.score_train,
                                                       scorer=self.scorer)

--- a/photonai/processing/outer_folds.py
+++ b/photonai/processing/outer_folds.py
@@ -63,7 +63,8 @@ class OuterFoldManager:
                  cache_folder=None,
                  cache_updater=None,
                  dummy_estimator=None,
-                 result_obj=None):
+                 result_obj=None,
+                 score_train: bool = True):
         self.outer_fold_id = outer_fold_id
         self.cross_validation_info = cross_validation_info
         self.scorer = Scorer(optimization_info.metrics)
@@ -71,6 +72,7 @@ class OuterFoldManager:
         self._pipe = pipe
         self.copy_pipe_fnc = self._pipe.copy_me
         self.dummy_estimator = dummy_estimator
+        self.score_train = score_train
 
         self.cache_folder = cache_folder
         self.cache_updater = cache_updater
@@ -246,6 +248,7 @@ class OuterFoldManager:
                                                         indices=self.cross_validation_info.outer_folds[self.outer_fold_id].test_indices,
                                                         metrics=self.optimization_info.metrics,
                                                         scorer=self.scorer,
+                                                        score_train=self.score_train,
                                                         **self._test_kwargs)
 
                 logger.debug('... scoring training data')
@@ -255,6 +258,7 @@ class OuterFoldManager:
                                                          metrics=self.optimization_info.metrics,
                                                          training=True,
                                                          scorer=self.scorer,
+                                                         score_train=self.score_train,
                                                          **self._validation_kwargs)
 
                 best_config_performance_mdb.training = train_score_mdb
@@ -386,7 +390,7 @@ class OuterFoldManager:
                 self.dummy_estimator.fit(dummy_y, self._validation_y)
                 train_scores = InnerFoldManager.score(self.dummy_estimator, self._validation_X, self._validation_y,
                                                       metrics=self.optimization_info.metrics,
-                                                      scorer=self.scorer)
+                                                      scorer=self.scorer, score_train=self.score_train)
 
                 # fill result tree with fold information
                 inner_fold = MDBInnerFold()
@@ -396,7 +400,7 @@ class OuterFoldManager:
                     test_scores = InnerFoldManager.score(self.dummy_estimator,
                                                          self._test_X, self._test_y,
                                                          metrics=self.optimization_info.metrics,
-                                                         scorer=self.scorer)
+                                                         scorer=self.scorer, score_train=self.score_train)
                     print_metrics("DUMMY", test_scores.metrics)
                     inner_fold.validation = test_scores
 

--- a/test/integration_tests/test_architecture.py
+++ b/test/integration_tests/test_architecture.py
@@ -67,6 +67,7 @@ class TestArchitectures(PhotonBaseTest):
                          use_test_set=eval_final_performance,
                          performance_constraints=performance_constraints,
                          cache_folder=cache_folder,
+                         raise_error=True,
                          verbosity=0)
         return pipe
 


### PR DESCRIPTION
This pr will add an parameter to the hyperpipe: score_train
If true, the default behaviour of the photon hyperpipe is exposed

if score_train is set to false, the train data is not scored and instead the metrics and results are filled with 0 values as placeholders.